### PR TITLE
Randomizer TMF 1.0.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The project combines features of [TMX](https://tm-exchange.com/), autosave Gbx f
 [![GitHub all releases](https://img.shields.io/github/downloads/BigBang1112/randomizer-tmf/total?style=for-the-badge)](https://github.com/BigBang1112/randomizer-tmf/releases)
 
 - ✔️ **50 downloads within 1 week** - Guaranteed support throughout 2023
-- **100 downloads** - Discord Rich Presence integration
+- ✔️ **100 downloads** - Discord Rich Presence integration **(coming right after refactoring)**
 - **300 downloads** - TMUF theme
 - **500 downloads** - Profile management (fresh account randomization)
 - **2000 downloads** - Automated RMC leaderboards

--- a/Src/RandomizerTMF.Logic/RandomizerConfig.cs
+++ b/Src/RandomizerTMF.Logic/RandomizerConfig.cs
@@ -17,4 +17,7 @@ public class RandomizerConfig
     /// {0} is the map name, {1} is the replay score (example: 9'59''59 in Race/Puzzle or 999_9'59''59 in Platform/Stunts), {2} is the player login.
     /// </summary>
     public string? ReplayFileFormat { get; set; } = Constants.DefaultReplayFileFormat;
+
+    public int ReplayParseFailRetries { get; set; } = 10;
+    public int ReplayParseFailDelayMs { get; set; } = 50;
 }

--- a/Src/RandomizerTMF.Logic/RandomizerEngine.cs
+++ b/Src/RandomizerTMF.Logic/RandomizerEngine.cs
@@ -189,34 +189,52 @@ public static partial class RandomizerEngine
         lastAutosaveUpdate = lastWriteTime;
         //
 
+        var retryCounter = 0;
+        
         CGameCtnReplayRecord replay;
 
-        try
+        while (true)
         {
-            // Any kind of autosave update section
-            
-            Logger.LogInformation("Analyzing a new file {autosavePath} in autosaves folder...", e.FullPath);
-
-            if (GameBox.ParseNode(e.FullPath) is not CGameCtnReplayRecord r)
+            try
             {
-                Logger.LogWarning("Found file {file} that is not a replay.", e.FullPath);
-                return;
+                // Any kind of autosave update section
+
+                Logger.LogInformation("Analyzing a new file {autosavePath} in autosaves folder...", e.FullPath);
+
+                if (GameBox.ParseNode(e.FullPath) is not CGameCtnReplayRecord r)
+                {
+                    Logger.LogWarning("Found file {file} that is not a replay.", e.FullPath);
+                    return;
+                }
+
+                if (r.MapInfo is null)
+                {
+                    Logger.LogWarning("Found replay {file} that has no map info.", e.FullPath);
+                    return;
+                }
+
+                AutosaveHeaders.TryAdd(r.MapInfo.Id, new AutosaveHeader(Path.GetFileName(e.FullPath), r));
+
+                replay = r;
+            }
+            catch (Exception ex)
+            {
+                retryCounter++;
+                
+                Logger.LogError(ex, "Error while analyzing a new file {autosavePath} in autosaves folder (retry {counter}/{maxRetries}).",
+                    e.FullPath, retryCounter, Config.ReplayParseFailRetries);
+
+                if (retryCounter >= Config.ReplayParseFailRetries)
+                {
+                    return;
+                }
+
+                Thread.Sleep(Config.ReplayParseFailDelayMs);
+
+                continue;
             }
 
-            if (r.MapInfo is null)
-            {
-                Logger.LogWarning("Found replay {file} that has no map info.", e.FullPath);
-                return;
-            }
-
-            AutosaveHeaders.TryAdd(r.MapInfo.Id, new AutosaveHeader(Path.GetFileName(e.FullPath), r));
-
-            replay = r;
-        }
-        catch (Exception ex)
-        {
-            Logger.LogError(ex, "Error while analyzing a new file {autosavePath} in autosaves folder.", e.FullPath);
-            return;
+            break;
         }
 
         try
@@ -786,59 +804,25 @@ public static partial class RandomizerEngine
             throw new RuleValidationException("Time limit cannot be above 9:59:59");
         }
 
-        foreach (var primaryType in Enum.GetValues<EPrimaryType>())
+        if (Config.Rules.RequestRules.EqualEnvironmentDistribution
+         && Config.Rules.RequestRules.EqualVehicleDistribution
+         && Config.Rules.RequestRules.Site != ESite.TMUF)
         {
-            if (primaryType is EPrimaryType.Race)
-            {
-                continue;
-            }
-            
-            if (Config.Rules.RequestRules.PrimaryType == primaryType
-            && (Config.Rules.RequestRules.Site == ESite.Any
-             || Config.Rules.RequestRules.Site.HasFlag(ESite.TMNF) || Config.Rules.RequestRules.Site.HasFlag(ESite.Nations)))
-            {
-                throw new RuleValidationException($"{primaryType} is not valid with TMNF or Nations Exchange");
-            }
-        }
-
-        if (Config.Rules.RequestRules.Environment is not null || Config.Rules.RequestRules.Vehicle is not null)
-        {
-            foreach (var env in Enum.GetValues<EEnvironment>())
-            {
-                if (env is EEnvironment.Stadium)
-                {
-                    continue;
-                }
-
-                if (Config.Rules.RequestRules.Site != ESite.Any && !Config.Rules.RequestRules.Site.HasFlag(ESite.TMNF) && !Config.Rules.RequestRules.Site.HasFlag(ESite.Nations))
-                {
-                    continue;
-                }
-                
-                if (Config.Rules.RequestRules.Environment?.Contains(env) == true)
-                {
-                    throw new RuleValidationException($"{env} is not valid with TMNF or Nations Exchange");
-                }
-
-                if (Config.Rules.RequestRules.Vehicle?.Contains(env) == true)
-                {
-                    throw new RuleValidationException($"{env}Car is not valid with TMNF or Nations Exchange");
-                }
-            }
+            throw new RuleValidationException("Equal environment and car distribution combined is only valid with TMUF Exchange");
         }
 
         if (Config.Rules.RequestRules.EqualEnvironmentDistribution
         && (Config.Rules.RequestRules.Site == ESite.Any
          || Config.Rules.RequestRules.Site.HasFlag(ESite.TMNF) || Config.Rules.RequestRules.Site.HasFlag(ESite.Nations)))
         {
-            throw new RuleValidationException($"Equal environment distribution is not valid with TMNF or Nations Exchange");
+            throw new RuleValidationException("Equal environment distribution is not valid with TMNF or Nations Exchange");
         }
 
         if (Config.Rules.RequestRules.EqualVehicleDistribution
         && (Config.Rules.RequestRules.Site == ESite.Any
          || Config.Rules.RequestRules.Site.HasFlag(ESite.TMNF) || Config.Rules.RequestRules.Site.HasFlag(ESite.Nations)))
         {
-            throw new RuleValidationException($"Equal vehicle distribution is not valid with TMNF or Nations Exchange");
+            throw new RuleValidationException("Equal vehicle distribution is not valid with TMNF or Nations Exchange");
         }
     }
 

--- a/Src/RandomizerTMF.Logic/RandomizerEngine.cs
+++ b/Src/RandomizerTMF.Logic/RandomizerEngine.cs
@@ -111,7 +111,9 @@ public static partial class RandomizerEngine
     public static StreamWriter LogWriter { get; private set; }
     public static StreamWriter? CurrentSessionLogWriter { get; private set; }
     public static bool SessionEnding { get; private set; }
-    
+
+    public static string? Version { get; } = typeof(RandomizerEngine).Assembly.GetName().Version?.ToString(3);
+
     [GeneratedRegex("[^a-zA-Z0-9_.]+")]
     private static partial Regex SpecialCharRegex();
 
@@ -148,7 +150,7 @@ public static partial class RandomizerEngine
         };
         
         Http = new HttpClient(socketHandler);
-        Http.DefaultRequestHeaders.UserAgent.TryParseAdd($"Randomizer TMF {typeof(RandomizerEngine).Assembly.GetName().Version}");
+        Http.DefaultRequestHeaders.UserAgent.TryParseAdd($"Randomizer TMF {Version}");
 
         Logger.LogInformation("Preparing general events...");
 
@@ -749,7 +751,7 @@ public static partial class RandomizerEngine
     {
         var startedAt = DateTimeOffset.Now;
 
-        CurrentSessionData = new SessionData(startedAt, Config.Rules);
+        CurrentSessionData = new SessionData(Version, startedAt, Config.Rules);
 
         if (CurrentSessionDataDirectoryPath is null)
         {

--- a/Src/RandomizerTMF.Logic/RandomizerEngine.cs
+++ b/Src/RandomizerTMF.Logic/RandomizerEngine.cs
@@ -826,13 +826,15 @@ public static partial class RandomizerEngine
         }
 
         if (Config.Rules.RequestRules.EqualEnvironmentDistribution
-         && Config.Rules.RequestRules.Site.HasFlag(ESite.TMNF) || Config.Rules.RequestRules.Site.HasFlag(ESite.Nations))
+        && (Config.Rules.RequestRules.Site == ESite.Any
+         || Config.Rules.RequestRules.Site.HasFlag(ESite.TMNF) || Config.Rules.RequestRules.Site.HasFlag(ESite.Nations)))
         {
             throw new RuleValidationException($"Equal environment distribution is not valid with TMNF or Nations Exchange");
         }
 
         if (Config.Rules.RequestRules.EqualVehicleDistribution
-         && Config.Rules.RequestRules.Site.HasFlag(ESite.TMNF) || Config.Rules.RequestRules.Site.HasFlag(ESite.Nations))
+        && (Config.Rules.RequestRules.Site == ESite.Any
+         || Config.Rules.RequestRules.Site.HasFlag(ESite.TMNF) || Config.Rules.RequestRules.Site.HasFlag(ESite.Nations)))
         {
             throw new RuleValidationException($"Equal vehicle distribution is not valid with TMNF or Nations Exchange");
         }

--- a/Src/RandomizerTMF.Logic/RandomizerEngine.cs
+++ b/Src/RandomizerTMF.Logic/RandomizerEngine.cs
@@ -796,12 +796,12 @@ public static partial class RandomizerEngine
     {
         if (Config.Rules.TimeLimit == TimeSpan.Zero)
         {
-            throw new RuleValidationException("Time limit cannot be 0:00:00");
+            throw new RuleValidationException("Time limit cannot be 0:00:00.");
         }
 
         if (Config.Rules.TimeLimit > new TimeSpan(9, 59, 59))
         {
-            throw new RuleValidationException("Time limit cannot be above 9:59:59");
+            throw new RuleValidationException("Time limit cannot be above 9:59:59.");
         }
 
         foreach (var primaryType in Enum.GetValues<EPrimaryType>())
@@ -815,45 +815,90 @@ public static partial class RandomizerEngine
             && (Config.Rules.RequestRules.Site is ESite.Any
              || Config.Rules.RequestRules.Site.HasFlag(ESite.TMNF) || Config.Rules.RequestRules.Site.HasFlag(ESite.Nations)))
             {
-                throw new RuleValidationException($"{primaryType} cannot be specifically selected with TMNF or Nations Exchange");
+                throw new RuleValidationException($"{primaryType} cannot be specifically selected with TMNF or Nations Exchange.");
             }
         }
 
-        if (Config.Rules.RequestRules.Environment is not null
-         && Config.Rules.RequestRules.Environment.Contains(EEnvironment.Stadium) == false
-        && (Config.Rules.RequestRules.Site is ESite.Any
-         || Config.Rules.RequestRules.Site.HasFlag(ESite.TMNF) || Config.Rules.RequestRules.Site.HasFlag(ESite.Nations)))
+        if (Config.Rules.RequestRules.Environment?.Count > 0)
         {
-            throw new RuleValidationException("Stadium has to be selected when environments are specified and TMNF or Nations Exchange is selected");
-        }
+            if (Config.Rules.RequestRules.Site.HasFlag(ESite.Sunrise)
+            && !Config.Rules.RequestRules.Environment.Contains(EEnvironment.Island)
+            && !Config.Rules.RequestRules.Environment.Contains(EEnvironment.Coast)
+            && !Config.Rules.RequestRules.Environment.Contains(EEnvironment.Bay))
+            {
+                throw new RuleValidationException("Island, Coast, or Bay has to be selected when environments are specified and Sunrise Exchange is selected.");
+            }
 
-        if (Config.Rules.RequestRules.Vehicle is not null
-        && !Config.Rules.RequestRules.Vehicle.Contains(EEnvironment.Stadium)
-        && (Config.Rules.RequestRules.Site is ESite.Any
-         || Config.Rules.RequestRules.Site.HasFlag(ESite.TMNF) || Config.Rules.RequestRules.Site.HasFlag(ESite.Nations)))
+            if (Config.Rules.RequestRules.Site.HasFlag(ESite.Original)
+            && !Config.Rules.RequestRules.Environment.Contains(EEnvironment.Snow)
+            && !Config.Rules.RequestRules.Environment.Contains(EEnvironment.Desert)
+            && !Config.Rules.RequestRules.Environment.Contains(EEnvironment.Rally))
+            {
+                throw new RuleValidationException("Snow, Desert, or Rally has to be selected when environments are specified and Original Exchange is selected.");
+            }
+
+            if (!Config.Rules.RequestRules.Environment.Contains(EEnvironment.Stadium)
+             && (Config.Rules.RequestRules.Site.HasFlag(ESite.TMNF) || Config.Rules.RequestRules.Site.HasFlag(ESite.Nations)))
+            {
+                throw new RuleValidationException("Stadium has to be selected when environments are specified and TMNF or Nations Exchange is selected.");
+            }
+
+            if (Config.Rules.RequestRules.Site.HasFlag(ESite.Sunrise) || Config.Rules.RequestRules.Site.HasFlag(ESite.Original))
+            {
+                foreach (var env in Config.Rules.RequestRules.Environment)
+                {
+                    if (Config.Rules.RequestRules.Vehicle?.Contains(env) == false)
+                    {
+                        throw new RuleValidationException("Envimix randomization is not allowed when Sunrise or Original Exchange is selected.");
+                    }
+                }
+            }
+        }
+        
+        if (Config.Rules.RequestRules.Vehicle?.Count > 0)
         {
-            throw new RuleValidationException("StadiumCar has to be selected when cars are specified and TMNF or Nations Exchange is selected");
+            if (!Config.Rules.RequestRules.Vehicle.Contains(EEnvironment.Island)
+             && !Config.Rules.RequestRules.Vehicle.Contains(EEnvironment.Coast)
+             && !Config.Rules.RequestRules.Vehicle.Contains(EEnvironment.Bay)
+              && Config.Rules.RequestRules.Site.HasFlag(ESite.Sunrise))
+            {
+                throw new RuleValidationException("IslandCar, CoastCar, or BayCar has to be selected when cars are specified and Sunrise Exchange is selected.");
+            }
+
+            if (!Config.Rules.RequestRules.Vehicle.Contains(EEnvironment.Snow)
+             && !Config.Rules.RequestRules.Vehicle.Contains(EEnvironment.Desert)
+             && !Config.Rules.RequestRules.Vehicle.Contains(EEnvironment.Rally)
+              && Config.Rules.RequestRules.Site.HasFlag(ESite.Original))
+            {
+                throw new RuleValidationException("SnowCar, DesertCar, or RallyCar has to be selected when cars are specified and Original Exchange is selected.");
+            }
+
+            if (!Config.Rules.RequestRules.Vehicle.Contains(EEnvironment.Stadium)
+             && (Config.Rules.RequestRules.Site.HasFlag(ESite.TMNF) || Config.Rules.RequestRules.Site.HasFlag(ESite.Nations)))
+            {
+                throw new RuleValidationException("StadiumCar has to be selected when cars are specified and TMNF or Nations Exchange is selected.");
+            }
         }
 
         if (Config.Rules.RequestRules.EqualEnvironmentDistribution
          && Config.Rules.RequestRules.EqualVehicleDistribution
          && Config.Rules.RequestRules.Site is not ESite.TMUF)
         {
-            throw new RuleValidationException("Equal environment and car distribution combined is only valid with TMUF Exchange");
+            throw new RuleValidationException("Equal environment and car distribution combined is only valid with TMUF Exchange.");
         }
 
         if (Config.Rules.RequestRules.EqualEnvironmentDistribution
         && (Config.Rules.RequestRules.Site is ESite.Any
          || Config.Rules.RequestRules.Site.HasFlag(ESite.TMNF) || Config.Rules.RequestRules.Site.HasFlag(ESite.Nations)))
         {
-            throw new RuleValidationException("Equal environment distribution is not valid with TMNF or Nations Exchange");
+            throw new RuleValidationException("Equal environment distribution is not valid with TMNF or Nations Exchange.");
         }
 
         if (Config.Rules.RequestRules.EqualVehicleDistribution
         && (Config.Rules.RequestRules.Site is ESite.Any
          || Config.Rules.RequestRules.Site.HasFlag(ESite.TMNF) || Config.Rules.RequestRules.Site.HasFlag(ESite.Nations)))
         {
-            throw new RuleValidationException("Equal vehicle distribution is not valid with TMNF or Nations Exchange");
+            throw new RuleValidationException("Equal vehicle distribution is not valid with TMNF or Nations Exchange.");
         }
     }
 

--- a/Src/RandomizerTMF.Logic/RandomizerEngine.cs
+++ b/Src/RandomizerTMF.Logic/RandomizerEngine.cs
@@ -804,22 +804,53 @@ public static partial class RandomizerEngine
             throw new RuleValidationException("Time limit cannot be above 9:59:59");
         }
 
+        foreach (var primaryType in Enum.GetValues<EPrimaryType>())
+        {
+            if (primaryType is EPrimaryType.Race)
+            {
+                continue;
+            }
+
+            if (Config.Rules.RequestRules.PrimaryType == primaryType
+            && (Config.Rules.RequestRules.Site is ESite.Any
+             || Config.Rules.RequestRules.Site.HasFlag(ESite.TMNF) || Config.Rules.RequestRules.Site.HasFlag(ESite.Nations)))
+            {
+                throw new RuleValidationException($"{primaryType} cannot be specifically selected with TMNF or Nations Exchange");
+            }
+        }
+
+        if (Config.Rules.RequestRules.Environment is not null
+         && Config.Rules.RequestRules.Environment.Contains(EEnvironment.Stadium) == false
+        && (Config.Rules.RequestRules.Site is ESite.Any
+         || Config.Rules.RequestRules.Site.HasFlag(ESite.TMNF) || Config.Rules.RequestRules.Site.HasFlag(ESite.Nations)))
+        {
+            throw new RuleValidationException("Stadium has to be selected when environments are specified and TMNF or Nations Exchange is selected");
+        }
+
+        if (Config.Rules.RequestRules.Vehicle is not null
+        && !Config.Rules.RequestRules.Vehicle.Contains(EEnvironment.Stadium)
+        && (Config.Rules.RequestRules.Site is ESite.Any
+         || Config.Rules.RequestRules.Site.HasFlag(ESite.TMNF) || Config.Rules.RequestRules.Site.HasFlag(ESite.Nations)))
+        {
+            throw new RuleValidationException("StadiumCar has to be selected when cars are specified and TMNF or Nations Exchange is selected");
+        }
+
         if (Config.Rules.RequestRules.EqualEnvironmentDistribution
          && Config.Rules.RequestRules.EqualVehicleDistribution
-         && Config.Rules.RequestRules.Site != ESite.TMUF)
+         && Config.Rules.RequestRules.Site is not ESite.TMUF)
         {
             throw new RuleValidationException("Equal environment and car distribution combined is only valid with TMUF Exchange");
         }
 
         if (Config.Rules.RequestRules.EqualEnvironmentDistribution
-        && (Config.Rules.RequestRules.Site == ESite.Any
+        && (Config.Rules.RequestRules.Site is ESite.Any
          || Config.Rules.RequestRules.Site.HasFlag(ESite.TMNF) || Config.Rules.RequestRules.Site.HasFlag(ESite.Nations)))
         {
             throw new RuleValidationException("Equal environment distribution is not valid with TMNF or Nations Exchange");
         }
 
         if (Config.Rules.RequestRules.EqualVehicleDistribution
-        && (Config.Rules.RequestRules.Site == ESite.Any
+        && (Config.Rules.RequestRules.Site is ESite.Any
          || Config.Rules.RequestRules.Site.HasFlag(ESite.TMNF) || Config.Rules.RequestRules.Site.HasFlag(ESite.Nations)))
         {
             throw new RuleValidationException("Equal vehicle distribution is not valid with TMNF or Nations Exchange");

--- a/Src/RandomizerTMF.Logic/RandomizerTMF.Logic.csproj
+++ b/Src/RandomizerTMF.Logic/RandomizerTMF.Logic.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<Version>1.0.2</Version>
+		<Version>1.0.3</Version>
 		<TargetFramework>net7.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>

--- a/Src/RandomizerTMF.Logic/SessionData.cs
+++ b/Src/RandomizerTMF.Logic/SessionData.cs
@@ -4,6 +4,7 @@ namespace RandomizerTMF.Logic;
 
 public class SessionData
 {
+    public string? Version { get; set; }
     public DateTimeOffset StartedAt { get; set; }
     public RandomizerRules Rules { get; set; }
 
@@ -12,13 +13,14 @@ public class SessionData
 
     public List<SessionDataMap> Maps { get; set; } = new();
 
-    public SessionData() : this(DateTimeOffset.Now, new())
+    public SessionData() : this(null, DateTimeOffset.Now, new())
     {
         
     }
 
-    public SessionData(DateTimeOffset startedAt, RandomizerRules rules)
+    public SessionData(string? version, DateTimeOffset startedAt, RandomizerRules rules)
     {
+        Version = version;
         StartedAt = startedAt;
         Rules = rules;
     }

--- a/Src/RandomizerTMF/RandomizerTMF.csproj
+++ b/Src/RandomizerTMF/RandomizerTMF.csproj
@@ -20,7 +20,7 @@
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<Version>1.0.2</Version>
+		<Version>1.0.3</Version>
 		<PublishSingleFile>true</PublishSingleFile>
 		<EnableCompressionInSingleFile>true</EnableCompressionInSingleFile>
 	</PropertyGroup>

--- a/Src/RandomizerTMF/Views/RequestRulesControl.axaml
+++ b/Src/RandomizerTMF/Views/RequestRulesControl.axaml
@@ -145,7 +145,7 @@
 		<TextBlock Grid.Row="9" Margin="0 8 0 12"
 				   HorizontalAlignment="Center"
 				   VerticalAlignment="Center"
-				   Opacity="0.5">If any horizontal layer above has no buttons toggled, it simply means "any of those".</TextBlock>
+				   Opacity="0.5">If any horizontal layer above has no buttons toggled, it simply means "all selected".</TextBlock>
 
 		<Grid Grid.Row="11" ShowGridLines="False">
 			<Grid.ColumnDefinitions>


### PR DESCRIPTION
- New rules validation system
  - Allowed certain combinations, which (when occurring) are stripped from the URL instead
  - Equal distributions are no longer valid with no site selected
  - Disallowed other combinations:
    - Island(Car), Coast(Car), or Bay(Car) has to be selected when environments/cars are specified and Sunrise Exchange is selected
    - Snow(Car), Desert(Car), or Rally(Car) has to be selected when environments/cars are specified and Original Exchange is selected
    - Stadium(Car) has to be selected when environments/cars are specified and TMNF or Nations Exchange is selected
    - Envimix randomization is not allowed when Sunrise or Original Exchange is selected
- Added URL strip mechanism, which occurs in 3 cases:
  - TMNF or Nations Exchange -> environment, car, or gamemode is explicitly defined in the URL
  - No site is explicitly selected and Sunrise or Original Exchange is picked -> invalid environment or vehicle is explicitly selected
  - No site is explicitly selected and Sunrise or Original Exchange is picked -> envimix combination is explicitly defined in the URL
- Added retry policy to failed replay parses in autosave when detected
  - If an exception is thrown when trying to parse the Gbx, 10 retries are made (`ReplayParseFailRetries` in `Config.yml`) with a 50ms delay (`ReplayParseFailDelayMs` in `Config.yml`).
- Added `Version` (application version) to session data
- In the Session data window, booleans are visually simplified to not include `: True` and are not included at all if they are `False`