### PR TITLE
Refactor part 1: Divide RandomizerEngine into multiple classes

### DIFF
--- a/Src/RandomizerTMF.Logic/AutosaveScanner.cs
+++ b/Src/RandomizerTMF.Logic/AutosaveScanner.cs
@@ -1,4 +1,11 @@
-﻿using System.Collections.Concurrent;
+﻿using GBX.NET.Engines.Game;
+using GBX.NET;
+using Microsoft.Extensions.Logging;
+using System.Collections.Concurrent;
+using GBX.NET.Exceptions;
+using RandomizerTMF.Logic.Exceptions;
+using System.Diagnostics;
+using TmEssentials;
 
 namespace RandomizerTMF.Logic;
 
@@ -25,4 +32,221 @@ public static class AutosaveScanner
 
     public static FileSystemWatcher AutosaveWatcher { get; }
 
+    static AutosaveScanner()
+    {
+        AutosaveWatcher = new FileSystemWatcher
+        {
+            NotifyFilter = NotifyFilters.FileName | NotifyFilters.LastWrite,
+            Filter = "*.Replay.gbx"
+        };
+
+        AutosaveWatcher.Changed += AutosaveCreatedOrChanged;
+    }
+
+    private static DateTime lastAutosaveUpdate = DateTime.MinValue;
+
+    private static void AutosaveCreatedOrChanged(object sender, FileSystemEventArgs e)
+    {
+        // Hack to fix the issue of this event sometimes running twice
+        var lastWriteTime = File.GetLastWriteTime(e.FullPath);
+
+        if (lastWriteTime == lastAutosaveUpdate)
+        {
+            return;
+        }
+
+        lastAutosaveUpdate = lastWriteTime;
+        //
+
+        var retryCounter = 0;
+
+        CGameCtnReplayRecord replay;
+
+        while (true)
+        {
+            try
+            {
+                // Any kind of autosave update section
+
+                RandomizerEngine.Logger.LogInformation("Analyzing a new file {autosavePath} in autosaves folder...", e.FullPath);
+
+                if (GameBox.ParseNode(e.FullPath) is not CGameCtnReplayRecord r)
+                {
+                    RandomizerEngine.Logger.LogWarning("Found file {file} that is not a replay.", e.FullPath);
+                    return;
+                }
+
+                if (r.MapInfo is null)
+                {
+                    RandomizerEngine.Logger.LogWarning("Found replay {file} that has no map info.", e.FullPath);
+                    return;
+                }
+
+                AutosaveHeaders.TryAdd(r.MapInfo.Id, new AutosaveHeader(Path.GetFileName(e.FullPath), r));
+
+                replay = r;
+            }
+            catch (Exception ex)
+            {
+                retryCounter++;
+
+                RandomizerEngine.Logger.LogError(ex, "Error while analyzing a new file {autosavePath} in autosaves folder (retry {counter}/{maxRetries}).",
+                    e.FullPath, retryCounter, RandomizerEngine.Config.ReplayParseFailRetries);
+
+                if (retryCounter >= RandomizerEngine.Config.ReplayParseFailRetries)
+                {
+                    return;
+                }
+
+                Thread.Sleep(RandomizerEngine.Config.ReplayParseFailDelayMs);
+
+                continue;
+            }
+
+            break;
+        }
+
+        if (RandomizerEngine.CurrentSession is null)
+        {
+            RandomizerEngine.Logger.LogInformation("No session is running, ending here.");
+            return;
+        }
+
+        RandomizerEngine.CurrentSession.AutosaveCreatedOrChanged(e.FullPath, replay);
+    }
+
+    /// <summary>
+    /// Scans the autosaves, which is required before running the session, to avoid already played maps.
+    /// </summary>
+    /// <returns>True if anything changed.</returns>
+    /// <exception cref="ImportantPropertyNullException"></exception>
+    public static bool ScanAutosaves()
+    {
+        if (FilePathManager.AutosavesDirectoryPath is null)
+        {
+            throw new ImportantPropertyNullException("Cannot scan autosaves without a valid user data directory path.");
+        }
+
+        var anythingChanged = false;
+
+        foreach (var file in Directory.EnumerateFiles(FilePathManager.AutosavesDirectoryPath).AsParallel())
+        {
+            try
+            {
+                if (GameBox.ParseNodeHeader(file) is not CGameCtnReplayRecord replay || replay.MapInfo is null)
+                {
+                    continue;
+                }
+
+                var mapUid = replay.MapInfo.Id;
+
+                if (AutosaveHeaders.ContainsKey(mapUid))
+                {
+                    continue;
+                }
+
+                AutosaveHeaders.TryAdd(mapUid, new AutosaveHeader(Path.GetFileName(file), replay));
+
+                anythingChanged = true;
+            }
+            catch (NotAGbxException)
+            {
+                // do nothing
+            }
+            catch (Exception ex)
+            {
+                RandomizerEngine.Logger.LogWarning(ex, "Gbx error found in the Autosaves folder when reading the header.");
+            }
+        }
+
+        HasAutosavesScanned = true;
+
+        return anythingChanged;
+    }
+
+    /// <summary>
+    /// Scans autosave details (mostly the map inside the replay and getting its info) that are then used to display more detailed information about a list of maps. Only some replay properties are stored to value memory.
+    /// </summary>
+    /// <exception cref="Exception"></exception>
+    public static void ScanDetailsFromAutosaves()
+    {
+        if (FilePathManager.AutosavesDirectoryPath is null)
+        {
+            throw new Exception("Cannot update autosaves without a valid user data directory path.");
+        }
+
+        foreach (var autosave in AutosaveHeaders.Keys)
+        {
+            try
+            {
+                UpdateAutosaveDetail(autosave);
+            }
+            catch (Exception ex)
+            {
+                // this happens in async context, logger may not be safe for that, some errors may get lost
+                Debug.WriteLine("Exception during autosave detail scan: " + ex);
+            }
+        }
+    }
+
+    private static void UpdateAutosaveDetail(string autosaveFileName)
+    {
+        var autosavePath = Path.Combine(FilePathManager.AutosavesDirectoryPath!, AutosaveHeaders[autosaveFileName].FilePath); // Forgive because it's a private method
+
+        if (GameBox.ParseNode(autosavePath) is not CGameCtnReplayRecord { Time: not null } replay)
+        {
+            return;
+        }
+
+        if (replay.Challenge is null)
+        {
+            return;
+        }
+
+        var mapName = TextFormatter.Deformat(replay.Challenge.MapName);
+        var mapEnv = (string)replay.Challenge.Collection;
+        var mapBronzeTime = replay.Challenge.TMObjective_BronzeTime ?? throw new ImportantPropertyNullException("Bronze time is null.");
+        var mapSilverTime = replay.Challenge.TMObjective_SilverTime ?? throw new ImportantPropertyNullException("Silver time is null.");
+        var mapGoldTime = replay.Challenge.TMObjective_GoldTime ?? throw new ImportantPropertyNullException("Gold time is null.");
+        var mapAuthorTime = replay.Challenge.TMObjective_AuthorTime ?? throw new ImportantPropertyNullException("Author time is null.");
+        var mapAuthorScore = replay.Challenge.AuthorScore ?? throw new ImportantPropertyNullException("AuthorScore is null.");
+        var mapMode = replay.Challenge.Mode;
+        var mapCarPure = replay.Challenge.PlayerModel?.Id;
+        var mapCar = string.IsNullOrEmpty(mapCarPure) ? $"{mapEnv}Car" : mapCarPure;
+
+        mapCar = mapCar switch
+        {
+            Constants.AlpineCar => Constants.SnowCar,
+            Constants.American or Constants.SpeedCar => Constants.DesertCar,
+            Constants.Rally => Constants.RallyCar,
+            Constants.SportCar => Constants.IslandCar,
+            _ => mapCar
+        };
+
+        var ghost = replay.GetGhosts().FirstOrDefault();
+
+        AutosaveDetails[autosaveFileName] = new(
+            replay.Time.Value,
+            Score: ghost?.StuntScore,
+            Respawns: ghost?.Respawns,
+            mapName,
+            mapEnv,
+            mapCar,
+            mapBronzeTime,
+            mapSilverTime,
+            mapGoldTime,
+            mapAuthorTime,
+            mapAuthorScore,
+            mapMode);
+    }
+
+    /// <summary>
+    /// Cleans up the autosave storage and, most importantly, restricts the engine from functionalities that require the autosaves (<see cref="HasAutosavesScanned"/>).
+    /// </summary>
+    public static void ResetAutosaves()
+    {
+        AutosaveHeaders.Clear();
+        AutosaveDetails.Clear();
+        HasAutosavesScanned = false;
+    }
 }

--- a/Src/RandomizerTMF.Logic/AutosaveScanner.cs
+++ b/Src/RandomizerTMF.Logic/AutosaveScanner.cs
@@ -1,0 +1,28 @@
+﻿using System.Collections.Concurrent;
+
+namespace RandomizerTMF.Logic;
+
+public static class AutosaveScanner
+{
+    private static bool hasAutosavesScanned;
+    
+    /// <summary>
+    /// If the map UIDs of the autosaves have been fully stored to the <see cref="AutosaveHeaders"/> and <see cref="AutosavePaths"/> dictionaries.
+    /// This property is required to be true in order to start a new session. It also handles the state of <see cref="AutosaveWatcher"/>, to catch other autosaves that might be created while the program is running.
+    /// </summary>
+    public static bool HasAutosavesScanned
+    {
+        get => hasAutosavesScanned;
+        private set
+        {
+            hasAutosavesScanned = value;
+            AutosaveWatcher.EnableRaisingEvents = value;
+        }
+    }
+
+    public static ConcurrentDictionary<string, AutosaveHeader> AutosaveHeaders { get; } = new();
+    public static ConcurrentDictionary<string, AutosaveDetails> AutosaveDetails { get; } = new();
+
+    public static FileSystemWatcher AutosaveWatcher { get; }
+
+}

--- a/Src/RandomizerTMF.Logic/CompiledRegex.cs
+++ b/Src/RandomizerTMF.Logic/CompiledRegex.cs
@@ -1,0 +1,9 @@
+﻿using System.Text.RegularExpressions;
+
+namespace RandomizerTMF.Logic;
+
+internal static partial class CompiledRegex
+{
+    [GeneratedRegex("[^a-zA-Z0-9_.]+")]
+    public static partial Regex SpecialCharRegex();
+}

--- a/Src/RandomizerTMF.Logic/CurrentSession.cs
+++ b/Src/RandomizerTMF.Logic/CurrentSession.cs
@@ -1,0 +1,379 @@
+﻿using GBX.NET;
+using GBX.NET.Engines.Game;
+using Microsoft.Extensions.Logging;
+using RandomizerTMF.Logic.Exceptions;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Net;
+using TmEssentials;
+using static GBX.NET.Engines.Game.CGameGhost;
+
+namespace RandomizerTMF.Logic;
+
+public class CurrentSession
+{
+    private readonly MapDownloader mapDownloader;
+    private readonly RandomizerConfig config;
+    private readonly TMForever game;
+    private readonly HttpClient http;
+    private readonly ILogger logger;
+
+    private bool isActualSkipCancellation;
+    
+    public Stopwatch Watch { get; } = new();
+    public CancellationTokenSource TokenSource { get; } = new();
+
+    public Task? Task { get; internal set; }
+
+    public CancellationTokenSource? SkipTokenSource { get; private set; }
+
+    public SessionMap? Map { get; set; }
+
+    public SessionData? Data { get; set; }
+
+    // This "trilogy" handles the storage of played maps. If the player didn't receive at least gold and didn't skip it, it is not counted in the progress.
+    // It may (?) be better to wrap the CGameCtnChallenge into "CompletedMap" and have status of it being "gold", "author", or "skipped", and better handle that to make it script-friendly.
+    public Dictionary<string, SessionMap> GoldMaps { get; } = new();
+    public Dictionary<string, SessionMap> AuthorMaps { get; } = new();
+    public Dictionary<string, SessionMap> SkippedMaps { get; } = new();
+    
+    public StreamWriter? LogWriter { get; set; }
+
+    public CurrentSession(MapDownloader mapDownloader,
+                          RandomizerConfig config,
+                          TMForever game,
+                          HttpClient http,
+                          ILogger logger)
+    {
+        this.mapDownloader = mapDownloader;
+        this.config = config;
+        this.game = game;
+        this.http = http;
+        this.logger = logger;
+    }
+
+    private static void Status(string status)
+    {
+        RandomizerEngine.OnStatus(status);
+    }
+
+    public void Start()
+    {
+        Task = Task.Run(() => RunSessionSafeAsync(TokenSource.Token), TokenSource.Token);
+    }
+    
+    /// <summary>
+    /// Runs the session in a way it won't ever throw an exception. Clears the session after its end as well.
+    /// </summary>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    private async Task RunSessionSafeAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            await RunSessionAsync(cancellationToken);
+        }
+        catch (TaskCanceledException)
+        {
+            Status("Session ended.");
+        }
+        catch (InvalidSessionException)
+        {
+            Status("Session ended. No maps found.");
+        }
+        catch (Exception ex)
+        {
+            Status("Session ended due to error.");
+            logger.LogError(ex, "Error during session.");
+        }
+    }
+
+    /// <summary>
+    /// Does the actual work during a running session. That this method ends means the session also ends. It does NOT clean up the session after its end.
+    /// </summary>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    /// <exception cref="TaskCanceledException"></exception>
+    private async Task RunSessionAsync(CancellationToken cancellationToken)
+    {
+        if (config.GameDirectory is null)
+        {
+            throw new UnreachableException("Game directory is null");
+        }
+
+        Validator.ValidateRules(config.Rules);
+        
+        Data = SessionData.Initialize(config, logger);
+
+        LogWriter = new StreamWriter(Path.Combine(Data.DirectoryPath, Constants.SessionLog))
+        {
+            AutoFlush = true
+        };
+
+        if (logger is LoggerToFile loggerToFile) // Maybe needs to be nicer
+        {
+            loggerToFile.Writers = ImmutableArray.Create(LogWriter, RandomizerEngine.LogWriter);
+        }
+
+        while (true)
+        {
+            // This try block is used to handle map requests and their HTTP errors, mostly.
+
+            try
+            {
+                await mapDownloader.PrepareNewMapAsync(this, cancellationToken);
+                Data?.Save(); // May not be super necessary?
+            }
+            catch (HttpRequestException)
+            {
+                Status("Failed to fetch a track. Retrying...");
+                await Task.Delay(1000, cancellationToken);
+                continue;
+            }
+            catch (MapValidationException)
+            {
+                logger.LogInformation("Map has not passed the validator, attempting another one...");
+                await Task.Delay(500, cancellationToken);
+                continue;
+            }
+            catch (InvalidSessionException)
+            {
+                logger.LogWarning("Session is invalid.");
+                throw;
+            }
+            catch (TaskCanceledException)
+            {
+                logger.LogInformation("Session terminated during map request.");
+                throw;
+            }
+            catch (Exception ex)
+            {
+                Status("Error! Check the log for more details.");
+                logger.LogError(ex, "An error occurred during map request.");
+
+                await Task.Delay(1000, cancellationToken);
+
+                continue;
+            }
+
+            await PlayMapAsync(cancellationToken);
+        }
+    }
+
+    /// <summary>
+    /// Handles the play loop of a map. Throws cancellation exception on session end (not the map end).
+    /// </summary>
+    /// <exception cref="TaskCanceledException"></exception>
+    private async Task PlayMapAsync(CancellationToken cancellationToken)
+    {
+        // Hacky last moment validations
+
+        if (Map is null)
+        {
+            throw new UnreachableException("CurrentSessionMap is null");
+        }
+
+        if (Map.FilePath is null)
+        {
+            throw new UnreachableException("CurrentSessionMapSavePath is null");
+        }
+
+        // Map starts here
+
+        Status("Starting the map...");
+
+        game.OpenFile(Map.FilePath);
+
+        Watch.Start();
+
+        SkipTokenSource = new CancellationTokenSource();
+        
+        RandomizerEngine.OnMapStarted();
+
+        Status("Playing the map...");
+
+        // This loop either softly stops when the map is skipped by the player
+        // or hardly stops when author medal is received / time limit is reached, End Session was clicked or an exception was thrown in general
+
+        // SkipTokenSource is used within the session to skip a map, while CurrentSessionTokenSource handles the whole session cancellation
+
+        while (!SkipTokenSource.IsCancellationRequested)
+        {
+            if (Watch.Elapsed >= config.Rules.TimeLimit) // Time limit reached case
+            {
+                if (TokenSource is null)
+                {
+                    throw new UnreachableException("CurrentSessionTokenSource is null");
+                }
+
+                // Will cause the Task.Delay below to throw a cancellation exception
+                // Code outside of the while loop wont be reached
+                TokenSource.Cancel();
+            }
+
+            await Task.Delay(20, cancellationToken);
+        }
+
+        Watch.Stop(); // Time is paused until the next map starts
+
+        if (isActualSkipCancellation) // When its a manual skip and not an automated skip by author medal receive
+        {
+            Status("Skipping the map...");
+
+            // Apply the rules related to manual map skip
+            // This part has a scripting potential too if properly implemented
+
+            SkipManually(Map);
+
+            isActualSkipCancellation = false;
+        }
+
+        Status("Ending the map...");
+
+        StopTrackingMap();
+
+        // Map is no longer tracked at this point
+    }
+
+    public void StopTrackingMap()
+    {
+        SkipTokenSource = null;
+        Map = null;
+        RandomizerEngine.OnMapEnded();
+    }
+    
+    private void SkipManually(SessionMap map)
+    {
+        // If the player didn't receive at least a gold medal, the skip is counted (author medal automatically skips the map)
+        if (GoldMaps.ContainsKey(map.MapUid) == false)
+        {
+            SkippedMaps.TryAdd(map.MapUid, map);
+            map.LastTimestamp = Watch.Elapsed;
+            Data?.SetMapResult(map, Constants.Skipped);
+        }
+
+        // In other words, if the player received at least a gold medal, the skip is forgiven
+
+        // MapSkip event is thrown to update the UI
+        RandomizerEngine.OnMapSkip();
+    }
+
+    internal void AutosaveCreatedOrChanged(string fullPath, CGameCtnReplayRecord replay)
+    {
+        try
+        {
+            // Current session map autosave update section
+
+            if (replay.MapInfo is null)
+            {
+                logger.LogWarning("Found autosave {autosavePath} with missing map info.", fullPath);
+                return;
+            }
+
+            if (Map is null)
+            {
+                logger.LogWarning("Found autosave {autosavePath} for map {mapUid} while no session is running.", fullPath, replay.MapInfo.Id);
+                return;
+            }
+
+            if (Map.MapInfo != replay.MapInfo)
+            {
+                logger.LogWarning("Found autosave {autosavePath} for map {mapUid} while the current session map is {currentSessionMapUid}.", fullPath, replay.MapInfo.Id, Map.MapInfo.Id);
+                return;
+            }
+            
+            Status("Copying the autosave...");
+
+            Data?.UpdateFromAutosave(fullPath, Map, replay, Watch.Elapsed);
+
+            Status("Checking the autosave...");
+
+            // New autosave from the current map, save it into session for progression reasons
+
+            // The following part has a scriptable potential
+            // There are different medal rules for each gamemode (and where to look for validating)
+            // So that's why the code looks like this for the time being
+
+            if (Map.ChallengeParameters?.AuthorTime is null)
+            {
+                logger.LogWarning("Found autosave {autosavePath} for map {mapName} ({mapUid}) that has no author time.",
+                    fullPath,
+                    TextFormatter.Deformat(Map.Map.MapName).Trim(),
+                    replay.MapInfo.Id);
+
+                SkipTokenSource?.Cancel();
+            }
+            else
+            {
+                var ghost = replay.GetGhosts().First();
+
+                if ((Map.Mode is CGameCtnChallenge.PlayMode.Race or CGameCtnChallenge.PlayMode.Puzzle && replay.Time <= Map.ChallengeParameters.AuthorTime)
+                 || (Map.Mode is CGameCtnChallenge.PlayMode.Platform && ((Map.ChallengeParameters.AuthorScore > 0 && ghost.Respawns <= Map.ChallengeParameters.AuthorScore) || (ghost.Respawns == 0 && replay.Time <= Map.ChallengeParameters.AuthorTime)))
+                 || (Map.Mode is CGameCtnChallenge.PlayMode.Stunts && ghost.StuntScore >= Map.ChallengeParameters.AuthorScore))
+                {
+                    AuthorMedalReceived(Map);
+
+                    SkipTokenSource?.Cancel();
+                }
+                else if ((Map.Mode is CGameCtnChallenge.PlayMode.Race or CGameCtnChallenge.PlayMode.Puzzle && replay.Time <= Map.ChallengeParameters.GoldTime)
+                      || (Map.Mode is CGameCtnChallenge.PlayMode.Platform && ghost.Respawns <= Map.ChallengeParameters.GoldTime.GetValueOrDefault().TotalMilliseconds)
+                      || (Map.Mode is CGameCtnChallenge.PlayMode.Stunts && ghost.StuntScore >= Map.ChallengeParameters.GoldTime.GetValueOrDefault().TotalMilliseconds))
+                {
+                    GoldMedalReceived(Map);
+                }
+            }
+
+            Status("Playing the map...");
+        }
+        catch (Exception ex)
+        {
+            Status("Error when checking the autosave...");
+            logger.LogError(ex, "Error when checking the autosave {autosavePath}.", fullPath);
+        }
+    }
+
+    private void GoldMedalReceived(SessionMap map)
+    {
+        GoldMaps.TryAdd(map.MapUid, map);
+        map.LastTimestamp = Watch.Elapsed;
+        Data?.SetMapResult(map, Constants.GoldMedal);
+
+        RandomizerEngine.OnMedalUpdate();
+    }
+
+    private void AuthorMedalReceived(SessionMap map)
+    {
+        GoldMaps.Remove(map.MapUid);
+        AuthorMaps.TryAdd(map.MapUid, map);
+        map.LastTimestamp = Watch.Elapsed;
+        Data?.SetMapResult(map, Constants.AuthorMedal);
+
+        RandomizerEngine.OnMedalUpdate();
+    }
+
+    public void Stop()
+    {
+        StopTrackingMap();
+        Watch.Stop();
+        Data?.SetReadOnlySessionYml();
+        LogWriter?.Dispose();
+    }
+
+    public Task SkipMapAsync()
+    {
+        Status("Requested to skip the map...");
+        isActualSkipCancellation = true;
+        SkipTokenSource?.Cancel();
+        return Task.CompletedTask;
+    }
+
+    public void ReloadMap()
+    {
+        logger.LogInformation("Reloading the map...");
+
+        if (Map?.FilePath is not null)
+        {
+            game.OpenFile(Map.FilePath);
+        }
+    }
+}

--- a/Src/RandomizerTMF.Logic/FilePathManager.cs
+++ b/Src/RandomizerTMF.Logic/FilePathManager.cs
@@ -28,8 +28,64 @@ public static class FilePathManager
     public static string? DownloadedDirectoryPath { get; private set; }
     public const string SessionsDirectoryPath = Constants.Sessions;
 
+    public static string? TmForeverExeFilePath { get; private set; }
+    public static string? TmUnlimiterExeFilePath { get; private set; }
+
     public static string ClearFileName(string fileName)
     {
         return string.Join('_', fileName.Split(Path.GetInvalidFileNameChars()));
+    }
+
+    public static GameDirInspectResult UpdateGameDirectory(string gameDirectoryPath)
+    {
+        RandomizerEngine.Config.GameDirectory = gameDirectoryPath;
+
+        var nadeoIniFilePath = Path.Combine(gameDirectoryPath, Constants.NadeoIni);
+        var tmForeverExeFilePath = Path.Combine(gameDirectoryPath, Constants.TmForeverExe);
+        var tmUnlimiterExeFilePath = Path.Combine(gameDirectoryPath, Constants.TmInifinityExe);
+
+        var nadeoIniException = default(Exception);
+        var tmForeverExeException = default(Exception);
+        var tmUnlimiterExeException = default(Exception);
+
+        try
+        {
+            var nadeoIni = NadeoIni.Parse(nadeoIniFilePath);
+            var myDocuments = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
+            var newUserDataDirectoryPath = Path.Combine(myDocuments, nadeoIni.UserSubDir);
+
+            if (UserDataDirectoryPath != newUserDataDirectoryPath)
+            {
+                UserDataDirectoryPath = newUserDataDirectoryPath;
+
+                AutosaveScanner.ResetAutosaves();
+            }
+        }
+        catch (Exception ex)
+        {
+            nadeoIniException = ex;
+        }
+
+        try
+        {
+            using var fs = File.OpenRead(tmForeverExeFilePath);
+            TmForeverExeFilePath = tmForeverExeFilePath;
+        }
+        catch (Exception ex)
+        {
+            tmForeverExeException = ex;
+        }
+
+        try
+        {
+            using var fs = File.OpenRead(tmUnlimiterExeFilePath);
+            TmUnlimiterExeFilePath = tmUnlimiterExeFilePath;
+        }
+        catch (Exception ex)
+        {
+            tmUnlimiterExeException = ex;
+        }
+
+        return new GameDirInspectResult(nadeoIniException, tmForeverExeException, tmUnlimiterExeException);
     }
 }

--- a/Src/RandomizerTMF.Logic/FilePathManager.cs
+++ b/Src/RandomizerTMF.Logic/FilePathManager.cs
@@ -1,0 +1,35 @@
+﻿namespace RandomizerTMF.Logic;
+
+public static class FilePathManager
+{
+    private static string? userDataDirectoryPath;
+    
+    /// <summary>
+    /// General directory of the user data. It also sets the <see cref="AutosavesDirectoryPath"/>, <see cref="DownloadedDirectoryPath"/>, and <see cref="AutosaveWatcher"/> path with it.
+    /// </summary>
+    public static string? UserDataDirectoryPath
+    {
+        get => userDataDirectoryPath;
+        set
+        {
+            userDataDirectoryPath = value;
+
+            AutosavesDirectoryPath = userDataDirectoryPath is null ? null : Path.Combine(userDataDirectoryPath, Constants.Tracks, Constants.Replays, Constants.Autosaves);
+            DownloadedDirectoryPath = userDataDirectoryPath is null ? null
+                : Path.Combine(userDataDirectoryPath, Constants.Tracks, Constants.Challenges, Constants.Downloaded, string.IsNullOrWhiteSpace(RandomizerEngine.Config.DownloadedMapsDirectory)
+                    ? Constants.DownloadedMapsDirectory
+                    : RandomizerEngine.Config.DownloadedMapsDirectory);
+
+            AutosaveScanner.AutosaveWatcher.Path = AutosavesDirectoryPath ?? "";
+        }
+    }
+
+    public static string? AutosavesDirectoryPath { get; private set; }
+    public static string? DownloadedDirectoryPath { get; private set; }
+    public const string SessionsDirectoryPath = Constants.Sessions;
+
+    public static string ClearFileName(string fileName)
+    {
+        return string.Join('_', fileName.Split(Path.GetInvalidFileNameChars()));
+    }
+}

--- a/Src/RandomizerTMF.Logic/LoggerToFile.cs
+++ b/Src/RandomizerTMF.Logic/LoggerToFile.cs
@@ -4,18 +4,18 @@ namespace RandomizerTMF.Logic;
 
 public class LoggerToFile : ILogger
 {
-    private readonly IList<StreamWriter> writers;
-
     internal LogScope? CurrentScope { get; set; }
+
+    public IList<StreamWriter> Writers { get; set; }
 
     public LoggerToFile(params StreamWriter[] writers)
     {
-        this.writers = writers;
+        Writers = writers;
     }
 
     public LoggerToFile(StreamWriter writer)
     {
-        writers = new List<StreamWriter> { writer };
+        Writers = new List<StreamWriter> { writer };
     }
 
     public IDisposable BeginScope<TState>(TState state) where TState : notnull
@@ -56,7 +56,7 @@ public class LoggerToFile : ILogger
 
         // CurrentScope is not utilized
 
-        foreach (var writer in writers)
+        foreach (var writer in Writers)
         {
             writer.WriteLine($"[{DateTime.Now}, {logLevel}] {message}");
 

--- a/Src/RandomizerTMF.Logic/MapDownloader.cs
+++ b/Src/RandomizerTMF.Logic/MapDownloader.cs
@@ -1,0 +1,243 @@
+﻿using GBX.NET.Engines.Game;
+using GBX.NET;
+using Microsoft.Extensions.Logging;
+using RandomizerTMF.Logic.Exceptions;
+using System.Diagnostics;
+using System.Net;
+using TmEssentials;
+using System.Threading;
+
+namespace RandomizerTMF.Logic;
+
+public class MapDownloader
+{
+    private readonly RandomizerConfig config;
+    private readonly HttpClient http;
+    private readonly ILogger logger;
+
+    private static readonly int requestMaxAttempts = 10;
+    private static int requestAttempt;
+
+    public MapDownloader(RandomizerConfig config, HttpClient http, ILogger logger)
+    {
+        this.config = config;
+        this.http = http;
+        this.logger = logger;
+    }
+
+    private void Status(string status)
+    {
+        
+    }
+    
+    /// <summary>
+    /// Requests, downloads, and allocates the map.
+    /// </summary>
+    /// <param name="cancellationToken"></param>
+    /// <exception cref="InvalidSessionException"></exception>
+    /// <exception cref="MapValidationException"></exception>
+    /// <returns>True if map has been prepared successfully, false if soft error/problem appeared (it's possible to ask for another track).</returns>
+    public async Task<bool> PrepareNewMapAsync(CurrentSession currentSession, CancellationToken cancellationToken)
+    {
+        var randomResponse = await FetchRandomTrackAsync(cancellationToken);
+
+        // Following code gathers the track ID from the HEAD response (and ensures everything makes sense)
+
+        var requestUri = GetRequestUriFromResponse(randomResponse);
+
+        if (requestUri is null)
+        {
+            return false;
+        }
+
+        var trackId = GetTrackIdFromUri(requestUri);
+
+        if (trackId is null)
+        {
+            return false;
+        }
+
+        // With the ID, it is possible to immediately download the track Gbx and process it with GBX.NET
+
+        var trackGbxResponse = await DownloadMapByTrackIdAsync(requestUri.Host, trackId, cancellationToken);
+
+        var map = await GetMapFromResponseAsync(trackGbxResponse, cancellationToken);
+
+        if (map is null)
+        {
+            return false;
+        }
+
+        // Map validation ensures that the player won't receive duplicate maps
+        // + ensures some additional filters like "No Unlimiter", which cannot be filtered on TMX
+        await ValidateMapAsync(map, cancellationToken);
+
+        // The map is saved to the defined DownloadedDirectoryPath using the FileName provided in ContentDisposition
+
+        await SaveMapAsync(trackGbxResponse, map.MapUid, cancellationToken);
+
+        var tmxLink = requestUri.ToString();
+
+        currentSession.Map = new SessionMap(map, randomResponse.Headers.Date ?? DateTimeOffset.Now, tmxLink); // The map should be ready to be played now
+
+        currentSession.Data?.Maps.Add(new()
+        {
+            Name = TextFormatter.Deformat(map.MapName),
+            Uid = map.MapUid,
+            TmxLink = tmxLink
+        });
+
+        return true;
+    }
+
+    private async Task SaveMapAsync(HttpResponseMessage trackGbxResponse, string mapUidFallback, CancellationToken cancellationToken)
+    {
+        Status("Saving the map...");
+
+        if (FilePathManager.DownloadedDirectoryPath is null)
+        {
+            throw new UnreachableException("Cannot update autosaves without a valid user data directory path.");
+        }
+
+        logger.LogDebug("Ensuring {dir} exists...", FilePathManager.DownloadedDirectoryPath);
+        Directory.CreateDirectory(FilePathManager.DownloadedDirectoryPath); // Ensures the directory really exists
+
+        logger.LogDebug("Preparing the file name...");
+
+        // Extracts the file name, and if it fails, it uses the MapUid as a fallback
+        var fileName = trackGbxResponse.Content.Headers.ContentDisposition?.FileName?.Trim('\"') ?? $"{mapUidFallback}.Challenge.Gbx";
+
+        // Validates the file name and fixes it if needed
+        fileName = FilePathManager.ClearFileName(fileName);
+
+        var mapSavePath = Path.Combine(FilePathManager.DownloadedDirectoryPath, fileName);
+
+        logger.LogInformation("Saving the map as {fileName}...", mapSavePath);
+
+        // WriteAllBytesAsync is used instead of GameBox.Save to ensure 1:1 data of the original map
+        var trackData = await trackGbxResponse.Content.ReadAsByteArrayAsync(cancellationToken);
+
+        await File.WriteAllBytesAsync(mapSavePath, trackData, cancellationToken);
+
+        logger.LogInformation("Map saved successfully!");
+    }
+
+    private async Task<HttpResponseMessage> FetchRandomTrackAsync(CancellationToken cancellationToken)
+    {
+        Status("Fetching random track...");
+
+        // Randomized URL is constructed with the ToUrl() method.
+        var requestUrl = config.Rules.RequestRules.ToUrl();
+
+        logger.LogDebug("Requesting generated URL: {url}", requestUrl);
+        var randomResponse = await http.HeadAsync(requestUrl, cancellationToken);
+
+        if (randomResponse.StatusCode == HttpStatusCode.NotFound)
+        {
+            // The session is ALWAYS invalid if there's no map that can be found.
+            // This DOES NOT relate to the lack of maps left that the user hasn't played.
+
+            logger.LogWarning("No map fulfills the randomization filter.");
+
+            throw new InvalidSessionException();
+        }
+
+        randomResponse.EnsureSuccessStatusCode(); // Handles server issues, should normally retry
+        
+        return randomResponse;
+    }
+
+    private Uri? GetRequestUriFromResponse(HttpResponseMessage response)
+    {
+        if (response.RequestMessage is null)
+        {
+            logger.LogWarning("Response from the HEAD request does not contain information about the request message. This is odd...");
+            return null;
+        }
+
+        if (response.RequestMessage.RequestUri is null)
+        {
+            logger.LogWarning("Response from the HEAD request does not contain information about the request URI. This is odd...");
+            return null;
+        }
+
+        return response.RequestMessage.RequestUri;
+    }
+
+    private string? GetTrackIdFromUri(Uri uri)
+    {
+        var trackId = uri.Segments.LastOrDefault();
+
+        if (trackId is null)
+        {
+            logger.LogWarning("Request URI does not contain any segments. This is very odd...");
+            return null;
+        }
+
+        return trackId;
+    }
+
+    private async Task<HttpResponseMessage> DownloadMapByTrackIdAsync(string host, string trackId, CancellationToken cancellationToken)
+    {
+        Status($"Downloading track {trackId}...");
+
+        var trackGbxUrl = $"https://{host}/trackgbx/{trackId}";
+
+        logger.LogDebug("Downloading track on {trackGbxUrl}...", trackGbxUrl);
+        using var trackGbxResponse = await http.GetAsync(trackGbxUrl, cancellationToken);
+        trackGbxResponse.EnsureSuccessStatusCode();
+
+        return trackGbxResponse;
+    }
+
+    private async Task<CGameCtnChallenge?> GetMapFromResponseAsync(HttpResponseMessage trackGbxResponse, CancellationToken cancellationToken)
+    {
+        using var stream = await trackGbxResponse.Content.ReadAsStreamAsync(cancellationToken);
+
+        // The map is gonna be parsed as it is downloading throughout
+
+        Status("Parsing the map...");
+
+        if (GameBox.ParseNode(stream) is CGameCtnChallenge map)
+        {
+            return map;
+        }
+
+        logger.LogWarning("Downloaded file is not a valid Gbx map file!");
+
+        return null;
+    }
+
+    private async Task ValidateMapAsync(CGameCtnChallenge map, CancellationToken cancellationToken)
+    {
+        Status("Validating the map...");
+
+        requestAttempt = 0;
+
+        if (Validator.ValidateMap(config, map, out string? invalidBlock))
+        {
+            return;
+        }
+        
+        // Attempts another track if invalid
+        requestAttempt++;
+
+        if (invalidBlock is not null)
+        {
+            Status($"{invalidBlock} in {map.Collection}");
+            logger.LogInformation("Map is invalid because {invalidBlock} is not valid for the {env} environment.", invalidBlock, map.Collection);
+            await Task.Delay(500, cancellationToken);
+        }
+
+        Status($"Map is invalid (attempt {requestAttempt}/{requestMaxAttempts}).");
+
+        if (requestAttempt >= requestMaxAttempts)
+        {
+            logger.LogWarning("Map is invalid after {MaxAttempts} attempts. Cancelling the session...", requestMaxAttempts);
+            requestAttempt = 0;
+            throw new InvalidSessionException();
+        }
+
+        throw new MapValidationException();
+    }
+}

--- a/Src/RandomizerTMF.Logic/MapDownloader.cs
+++ b/Src/RandomizerTMF.Logic/MapDownloader.cs
@@ -37,7 +37,7 @@ public class MapDownloader
     /// <exception cref="InvalidSessionException"></exception>
     /// <exception cref="MapValidationException"></exception>
     /// <returns>True if map has been prepared successfully, false if soft error/problem appeared (it's possible to ask for another track).</returns>
-    public async Task<bool> PrepareNewMapAsync(CurrentSession currentSession, CancellationToken cancellationToken)
+    public async Task<bool> PrepareNewMapAsync(Session currentSession, CancellationToken cancellationToken)
     {
         var randomResponse = await FetchRandomTrackAsync(cancellationToken);
 

--- a/Src/RandomizerTMF.Logic/RandomizerConfig.cs
+++ b/Src/RandomizerTMF.Logic/RandomizerConfig.cs
@@ -1,9 +1,13 @@
-﻿using YamlDotNet.Serialization;
+﻿using Microsoft.Extensions.Logging;
+using YamlDotNet.Core;
+using YamlDotNet.Serialization;
 
 namespace RandomizerTMF.Logic;
 
 public class RandomizerConfig
 {
+    private readonly ILogger? logger;
+
     public string? GameDirectory { get; set; }
     public string? DownloadedMapsDirectory { get; set; } = Constants.DownloadedMapsDirectory;
     
@@ -20,4 +24,61 @@ public class RandomizerConfig
 
     public int ReplayParseFailRetries { get; set; } = 10;
     public int ReplayParseFailDelayMs { get; set; } = 50;
+
+    public RandomizerConfig()
+    {
+
+    }
+
+    public RandomizerConfig(ILogger logger)
+    {
+        this.logger = logger;
+    }
+
+    /// <summary>
+    /// This method should be ran only at the start of the randomizer engine.
+    /// </summary>
+    /// <returns></returns>
+    public static RandomizerConfig GetOrCreate(ILogger logger)
+    {
+        var config = default(RandomizerConfig);
+
+        if (File.Exists(Constants.ConfigYml))
+        {
+            logger.LogInformation("Config file found, loading...");
+
+            try
+            {
+                using var reader = new StreamReader(Constants.ConfigYml);
+                config = Yaml.Deserializer.Deserialize<RandomizerConfig>(reader);
+            }
+            catch (YamlException ex)
+            {
+                logger.LogWarning(ex.InnerException, "Error while deserializing the config file ({configPath}; [{start}] - [{end}]).", Constants.ConfigYml, ex.Start, ex.End);
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "Error while deserializing the config file ({configPath}).", Constants.ConfigYml);
+            }
+        }
+
+        if (config is null)
+        {
+            logger.LogInformation("Config file not found or is corrupted, creating a new one...");
+            config = new RandomizerConfig(logger);
+        }
+
+        config.Save();
+
+        return config;
+    }
+
+    public void Save()
+    {
+        logger?.LogInformation("Saving the config file...");
+
+        File.WriteAllText(Constants.ConfigYml, Yaml.Serializer.Serialize(this));
+
+        logger?.LogInformation("Config file saved.");
+    }
 }

--- a/Src/RandomizerTMF.Logic/RandomizerEngine.cs
+++ b/Src/RandomizerTMF.Logic/RandomizerEngine.cs
@@ -1,30 +1,9 @@
-﻿using GBX.NET;
-using GBX.NET.Engines.Game;
-using GBX.NET.Exceptions;
-using Microsoft.Extensions.Logging;
-using RandomizerTMF.Logic.Exceptions;
-using RandomizerTMF.Logic.TypeConverters;
-using System.Diagnostics;
-using TmEssentials;
-using YamlDotNet.Serialization;
+﻿using Microsoft.Extensions.Logging;
 
 namespace RandomizerTMF.Logic;
 
 public static partial class RandomizerEngine
-{    
-    public static ISerializer YamlSerializer { get; } = new SerializerBuilder()
-        .WithTypeConverter(new DateOnlyConverter())
-        .WithTypeConverter(new DateTimeOffsetConverter())
-        .WithTypeConverter(new TimeInt32Converter())
-        .Build();
-
-    public static IDeserializer YamlDeserializer { get; } = new DeserializerBuilder()
-        .WithTypeConverter(new DateOnlyConverter())
-        .WithTypeConverter(new DateTimeOffsetConverter())
-        .WithTypeConverter(new TimeInt32Converter())
-        .IgnoreUnmatchedProperties()
-        .Build();
-
+{
     public static RandomizerConfig Config { get; }
     public static Dictionary<string, HashSet<string>> OfficialBlocks { get; }
 
@@ -116,7 +95,7 @@ public static partial class RandomizerEngine
             try
             {
                 using var reader = new StreamReader(Constants.ConfigYml);
-                config = YamlDeserializer.Deserialize<RandomizerConfig>(reader);
+                config = Yaml.Deserializer.Deserialize<RandomizerConfig>(reader);
             }
             catch (Exception ex)
             {
@@ -138,7 +117,7 @@ public static partial class RandomizerEngine
     private static Dictionary<string, HashSet<string>> GetOfficialBlocks()
     {
         using var reader = new StreamReader(Constants.OfficialBlocksYml);
-        return YamlDeserializer.Deserialize<Dictionary<string, HashSet<string>>>(reader);
+        return Yaml.Deserializer.Deserialize<Dictionary<string, HashSet<string>>>(reader);
     }
 
     public static GameDirInspectResult UpdateGameDirectory(string gameDirectoryPath)
@@ -203,7 +182,7 @@ public static partial class RandomizerEngine
     {
         Logger.LogInformation("Saving the config file...");
         
-        File.WriteAllText(Constants.ConfigYml, YamlSerializer.Serialize(config));
+        File.WriteAllText(Constants.ConfigYml, Yaml.Serializer.Serialize(config));
 
         Logger.LogInformation("Config file saved.");
     }

--- a/Src/RandomizerTMF.Logic/RandomizerEngine.cs
+++ b/Src/RandomizerTMF.Logic/RandomizerEngine.cs
@@ -44,7 +44,7 @@ public static partial class RandomizerEngine
 
         Logger.LogInformation("Loading config...");
 
-        Config = GetOrCreateConfig();
+        Config = RandomizerConfig.GetOrCreate(Logger);
 
         Logger.LogInformation("Loading official blocks...");
 
@@ -76,59 +76,11 @@ public static partial class RandomizerEngine
     public static void OnMapEnded() => MapEnded?.Invoke();
     public static void OnMapSkip() => MapSkip?.Invoke();
     public static void OnMedalUpdate() => MedalUpdate?.Invoke();
-
-    /// <summary>
-    /// This method should be ran only at the start of the randomizer engine.
-    /// </summary>
-    /// <returns></returns>
-    private static RandomizerConfig GetOrCreateConfig()
-    {
-        var config = default(RandomizerConfig);
-
-        if (File.Exists(Constants.ConfigYml))
-        {
-            Logger.LogInformation("Config file found, loading...");
-
-            try
-            {
-                using var reader = new StreamReader(Constants.ConfigYml);
-                config = Yaml.Deserializer.Deserialize<RandomizerConfig>(reader);
-            }
-            catch (Exception ex)
-            {
-                Logger.LogWarning(ex, "Error while deserializing the config file ({configPath}).", Constants.ConfigYml);
-            }
-        }
-
-        if (config is null)
-        {
-            Logger.LogInformation("Config file not found or is corrupted, creating a new one...");
-            config = new RandomizerConfig();
-        }
-
-        SaveConfig(config);
-
-        return config;
-    }
     
     private static Dictionary<string, HashSet<string>> GetOfficialBlocks()
     {
         using var reader = new StreamReader(Constants.OfficialBlocksYml);
         return Yaml.Deserializer.Deserialize<Dictionary<string, HashSet<string>>>(reader);
-    }
-
-    public static void SaveConfig()
-    {
-        SaveConfig(Config);
-    }
-
-    private static void SaveConfig(RandomizerConfig config)
-    {
-        Logger.LogInformation("Saving the config file...");
-        
-        File.WriteAllText(Constants.ConfigYml, Yaml.Serializer.Serialize(config));
-
-        Logger.LogInformation("Config file saved.");
     }
 
     /// <summary>
@@ -192,8 +144,10 @@ public static partial class RandomizerEngine
         }
         catch (TaskCanceledException)
         {
-            ClearCurrentSession(); // Just an ensure
+            
         }
+
+        ClearCurrentSession();
 
         SessionEnding = false;
     }

--- a/Src/RandomizerTMF.Logic/RandomizerEngine.cs
+++ b/Src/RandomizerTMF.Logic/RandomizerEngine.cs
@@ -9,9 +9,6 @@ public static partial class RandomizerEngine
 
     public static HttpClient Http { get; }
 
-    public static string? TmForeverExeFilePath { get; set; }
-    public static string? TmUnlimiterExeFilePath { get; set; }
-
     public static Session? CurrentSession { get; private set; }
     
     public static bool HasSessionRunning => CurrentSession is not null;
@@ -118,59 +115,6 @@ public static partial class RandomizerEngine
     {
         using var reader = new StreamReader(Constants.OfficialBlocksYml);
         return Yaml.Deserializer.Deserialize<Dictionary<string, HashSet<string>>>(reader);
-    }
-
-    public static GameDirInspectResult UpdateGameDirectory(string gameDirectoryPath)
-    {
-        Config.GameDirectory = gameDirectoryPath;
-
-        var nadeoIniFilePath = Path.Combine(gameDirectoryPath, Constants.NadeoIni);
-        var tmForeverExeFilePath = Path.Combine(gameDirectoryPath, Constants.TmForeverExe);
-        var tmUnlimiterExeFilePath = Path.Combine(gameDirectoryPath, Constants.TmInifinityExe);
-
-        var nadeoIniException = default(Exception);
-        var tmForeverExeException = default(Exception);
-        var tmUnlimiterExeException = default(Exception);
-
-        try
-        {
-            var nadeoIni = NadeoIni.Parse(nadeoIniFilePath);
-            var myDocuments = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
-            var newUserDataDirectoryPath = Path.Combine(myDocuments, nadeoIni.UserSubDir);
-
-            if (FilePathManager.UserDataDirectoryPath != newUserDataDirectoryPath)
-            {
-                FilePathManager.UserDataDirectoryPath = newUserDataDirectoryPath;
-
-                AutosaveScanner.ResetAutosaves();
-            }
-        }
-        catch (Exception ex)
-        {
-            nadeoIniException = ex;
-        }
-
-        try
-        {
-            using var fs = File.OpenRead(tmForeverExeFilePath);
-            TmForeverExeFilePath = tmForeverExeFilePath;
-        }
-        catch (Exception ex)
-        {
-            tmForeverExeException = ex;
-        }
-
-        try
-        {
-            using var fs = File.OpenRead(tmUnlimiterExeFilePath);
-            TmUnlimiterExeFilePath = tmUnlimiterExeFilePath;
-        }
-        catch (Exception ex)
-        {
-            tmUnlimiterExeException = ex;
-        }
-
-        return new GameDirInspectResult(nadeoIniException, tmForeverExeException, tmUnlimiterExeException);
     }
 
     public static void SaveConfig()

--- a/Src/RandomizerTMF.Logic/RandomizerEngine.cs
+++ b/Src/RandomizerTMF.Logic/RandomizerEngine.cs
@@ -58,7 +58,7 @@ public static partial class RandomizerEngine
     public static string? DownloadedDirectoryPath { get; private set; }
     public static string SessionsDirectoryPath => Constants.Sessions;
 
-    public static CurrentSession? CurrentSession { get; private set; }
+    public static Session? CurrentSession { get; private set; }
     
     public static bool HasSessionRunning => CurrentSession is not null;
 
@@ -480,7 +480,7 @@ public static partial class RandomizerEngine
             return;
         }
 
-        CurrentSession = new CurrentSession(
+        CurrentSession = new Session(
             new MapDownloader(Config, Http, Logger),
             Config,
             new TMForever(Config, Logger),

--- a/Src/RandomizerTMF.Logic/RandomizerEngine.cs
+++ b/Src/RandomizerTMF.Logic/RandomizerEngine.cs
@@ -6,8 +6,6 @@ using RandomizerTMF.Logic.Exceptions;
 using RandomizerTMF.Logic.TypeConverters;
 using System.Collections.Concurrent;
 using System.Diagnostics;
-using System.Net;
-using System.Text.RegularExpressions;
 using TmEssentials;
 using YamlDotNet.Serialization;
 
@@ -15,10 +13,6 @@ namespace RandomizerTMF.Logic;
 
 public static partial class RandomizerEngine
 {
-    private static readonly int requestMaxAttempts = 10;
-    private static int requestAttempt;
-
-    private static bool isActualSkipCancellation;
     private static string? userDataDirectoryPath;
     private static bool hasAutosavesScanned;
     
@@ -64,22 +58,8 @@ public static partial class RandomizerEngine
     public static string? DownloadedDirectoryPath { get; private set; }
     public static string SessionsDirectoryPath => Constants.Sessions;
 
-    public static Task? CurrentSession { get; private set; }
-    public static CancellationTokenSource? CurrentSessionTokenSource { get; private set; }
-    public static CancellationTokenSource? SkipTokenSource { get; private set; }
-    public static SessionMap? CurrentSessionMap { get; private set; }
-    public static string? CurrentSessionMapSavePath { get; private set; }
-    public static Stopwatch? CurrentSessionWatch { get; private set; }
-
-    public static SessionData? CurrentSessionData { get; private set; }
-    public static string? CurrentSessionDataDirectoryPath => CurrentSessionData is null ? null : Path.Combine(SessionsDirectoryPath, CurrentSessionData.StartedAtText);
-
-    // This "trilogy" handles the storage of played maps. If the player didn't receive at least gold and didn't skip it, it is not counted in the progress.
-    // It may (?) be better to wrap the CGameCtnChallenge into "CompletedMap" and have status of it being "gold", "author", or "skipped", and better handle that to make it script-friendly.
-    public static Dictionary<string, SessionMap> CurrentSessionGoldMaps { get; } = new();
-    public static Dictionary<string, SessionMap> CurrentSessionAuthorMaps { get; } = new();
-    public static Dictionary<string, SessionMap> CurrentSessionSkippedMaps { get; } = new();
-
+    public static CurrentSession? CurrentSession { get; private set; }
+    
     public static bool HasSessionRunning => CurrentSession is not null;
 
     /// <summary>
@@ -101,21 +81,18 @@ public static partial class RandomizerEngine
 
     public static FileSystemWatcher AutosaveWatcher { get; }
 
-    public static event Action? MapStarted;
-    public static event Action? MapEnded;
-    public static event Action? MapSkip;
-    public static event Action<string> Status;
-    public static event Action? MedalUpdate;
 
     public static ILogger Logger { get; private set; }
     public static StreamWriter LogWriter { get; private set; }
-    public static StreamWriter? CurrentSessionLogWriter { get; private set; }
     public static bool SessionEnding { get; private set; }
 
     public static string? Version { get; } = typeof(RandomizerEngine).Assembly.GetName().Version?.ToString(3);
 
-    [GeneratedRegex("[^a-zA-Z0-9_.]+")]
-    private static partial Regex SpecialCharRegex();
+    public static event Action<string>? Status;
+    public static event Action? MapStarted;
+    public static event Action? MapEnded;
+    public static event Action? MapSkip;
+    public static event Action? MedalUpdate;
 
     static RandomizerEngine()
     {
@@ -161,19 +138,24 @@ public static partial class RandomizerEngine
         };
 
         AutosaveWatcher.Changed += AutosaveCreatedOrChanged;
-
-        Status += RandomizerEngineStatus;
         
         Logger.LogInformation("Randomizer TMF initialized.");
     }
 
-    private static void RandomizerEngineStatus(string status)
+    public static void OnStatus(string status)
     {
         // Status kind of logging
         // Unlike regular logs, these are shown to the user in a module, while also written to the log file in its own way
         Logger.LogInformation("STATUS: {status}", status);
+
+        Status?.Invoke(status);
     }
-    
+
+    public static void OnMapStarted() => MapStarted?.Invoke();
+    public static void OnMapEnded() => MapEnded?.Invoke();
+    public static void OnMapSkip() => MapSkip?.Invoke();
+    public static void OnMedalUpdate() => MedalUpdate?.Invoke();
+
     private static DateTime lastAutosaveUpdate = DateTime.MinValue;
 
     private static void AutosaveCreatedOrChanged(object sender, FileSystemEventArgs e)
@@ -237,168 +219,13 @@ public static partial class RandomizerEngine
             break;
         }
 
-        try
+        if (CurrentSession is null)
         {
-            // Current session map autosave update section
-
-            if (CurrentSessionMap is null)
-            {
-                Logger.LogWarning("Found autosave {autosavePath} for map {mapUid} while no session is running.", e.FullPath, replay.MapInfo.Id);
-                return;
-            }
-
-            if (CurrentSessionMap.MapInfo != replay.MapInfo)
-            {
-                Logger.LogWarning("Found autosave {autosavePath} for map {mapUid} while the current session map is {currentSessionMapUid}.", e.FullPath, replay.MapInfo.Id, CurrentSessionMap.MapInfo.Id);
-                return;
-            }
-            
-            UpdateSessionDataFromAutosave(e.FullPath, CurrentSessionMap, replay);
-
-            Status("Checking the autosave...");
-
-            // New autosave from the current map, save it into session for progression reasons
-
-            // The following part has a scriptable potential
-            // There are different medal rules for each gamemode (and where to look for validating)
-            // So that's why the code looks like this for the time being
-
-            if (CurrentSessionMap.ChallengeParameters?.AuthorTime is null)
-            {
-                Logger.LogWarning("Found autosave {autosavePath} for map {mapName} ({mapUid}) that has no author time.",
-                    e.FullPath,
-                    TextFormatter.Deformat(CurrentSessionMap.Map.MapName).Trim(),
-                    replay.MapInfo.Id);
-
-                SkipTokenSource?.Cancel();
-            }
-            else
-            {
-                var ghost = replay.GetGhosts().First();
-
-                if ((CurrentSessionMap.Mode is CGameCtnChallenge.PlayMode.Race or CGameCtnChallenge.PlayMode.Puzzle && replay.Time <= CurrentSessionMap.ChallengeParameters.AuthorTime)
-                 || (CurrentSessionMap.Mode is CGameCtnChallenge.PlayMode.Platform && ((CurrentSessionMap.ChallengeParameters.AuthorScore > 0 && ghost.Respawns <= CurrentSessionMap.ChallengeParameters.AuthorScore) || (ghost.Respawns == 0 && replay.Time <= CurrentSessionMap.ChallengeParameters.AuthorTime)))
-                 || (CurrentSessionMap.Mode is CGameCtnChallenge.PlayMode.Stunts && ghost.StuntScore >= CurrentSessionMap.ChallengeParameters.AuthorScore))
-                {
-                    AuthorMedalReceived(CurrentSessionMap);
-
-                    SkipTokenSource?.Cancel();
-                }
-                else if ((CurrentSessionMap.Mode is CGameCtnChallenge.PlayMode.Race or CGameCtnChallenge.PlayMode.Puzzle && replay.Time <= CurrentSessionMap.ChallengeParameters.GoldTime)
-                      || (CurrentSessionMap.Mode is CGameCtnChallenge.PlayMode.Platform && ghost.Respawns <= CurrentSessionMap.ChallengeParameters.GoldTime.GetValueOrDefault().TotalMilliseconds)
-                      || (CurrentSessionMap.Mode is CGameCtnChallenge.PlayMode.Stunts && ghost.StuntScore >= CurrentSessionMap.ChallengeParameters.GoldTime.GetValueOrDefault().TotalMilliseconds))
-                {
-                    GoldMedalReceived(CurrentSessionMap);
-                }
-            }
-
-            Status("Playing the map...");
-        }
-        catch (Exception ex)
-        {
-            Status("Error when checking the autosave...");
-            Logger.LogError(ex, "Error when checking the autosave {autosavePath}.", e.FullPath);
-        }
-    }
-
-    private static void UpdateSessionDataFromAutosave(string fullPath, SessionMap map, CGameCtnReplayRecord replay)
-    {
-        if (CurrentSessionDataDirectoryPath is null)
-        {
+            Logger.LogInformation("No session is running, ending here.");
             return;
         }
 
-        Status("Copying the autosave...");
-
-        var score = map.Map.Mode switch
-        {
-            CGameCtnChallenge.PlayMode.Stunts => replay.GetGhosts().First().StuntScore + "_",
-            CGameCtnChallenge.PlayMode.Platform => replay.GetGhosts().First().Respawns + "_",
-            _ => ""
-        } + replay.Time.ToTmString(useHundredths: true, useApostrophe: true);
-
-        var mapName = SpecialCharRegex().Replace(TextFormatter.Deformat(map.Map.MapName).Trim(), "_");
-
-        var replayFileFormat = string.IsNullOrWhiteSpace(Config.ReplayFileFormat)
-            ? Constants.DefaultReplayFileFormat
-            : Config.ReplayFileFormat;
-        
-        var replayFileName = ClearFileName(string.Format(replayFileFormat, mapName, score, replay.PlayerLogin));
-
-        var replaysDir = Path.Combine(CurrentSessionDataDirectoryPath, Constants.Replays);
-        var replayFilePath = Path.Combine(replaysDir, replayFileName);
-
-        Directory.CreateDirectory(replaysDir);
-        File.Copy(fullPath, replayFilePath, overwrite: true);
-
-        if (CurrentSessionWatch is null)
-        {
-            return;
-        }
-        
-        CurrentSessionData?.Maps
-            .FirstOrDefault(x => x.Uid == map.MapUid)?
-            .Replays
-            .Add(new()
-            {
-                FileName = replayFileName,
-                Timestamp = CurrentSessionWatch.Elapsed
-            });
-        
-        SaveSessionData();
-    }
-
-    private static string ClearFileName(string fileName)
-    {
-        return string.Join('_', fileName.Split(Path.GetInvalidFileNameChars()));
-    }
-
-    private static void GoldMedalReceived(SessionMap map)
-    {
-        CurrentSessionGoldMaps.TryAdd(map.MapUid, map);
-        map.LastTimestamp = CurrentSessionWatch?.Elapsed;
-        SetMapResult(map, Constants.GoldMedal);
-
-        MedalUpdate?.Invoke();
-    }
-
-    private static void AuthorMedalReceived(SessionMap map)
-    {
-        CurrentSessionGoldMaps.Remove(map.MapUid);
-        CurrentSessionAuthorMaps.TryAdd(map.MapUid, map);
-        map.LastTimestamp = CurrentSessionWatch?.Elapsed;
-        SetMapResult(map, Constants.AuthorMedal);
-
-        MedalUpdate?.Invoke();
-    }
-
-    private static void Skipped(SessionMap map)
-    {
-        // If the player didn't receive at least a gold medal, the skip is counted (author medal automatically skips the map)
-        if (!CurrentSessionGoldMaps.ContainsKey(map.MapUid))
-        {
-            CurrentSessionSkippedMaps.TryAdd(map.MapUid, map);
-            map.LastTimestamp = CurrentSessionWatch?.Elapsed;
-            SetMapResult(map, Constants.Skipped);
-        }
-
-        // In other words, if the player received at least a gold medal, the skip is forgiven
-
-        // MapSkip event is thrown to update the UI
-        MapSkip?.Invoke();
-    }
-
-    private static void SetMapResult(SessionMap map, string result)
-    {
-        var dataMap = CurrentSessionData?.Maps.FirstOrDefault(x => x.Uid == map.MapUid);
-
-        if (dataMap is not null)
-        {
-            dataMap.Result = result;
-            dataMap.LastTimestamp = map.LastTimestamp;
-        }
-        
-        SaveSessionData();
+        CurrentSession.AutosaveCreatedOrChanged(e.FullPath, replay);
     }
 
     /// <summary>
@@ -516,20 +343,6 @@ public static partial class RandomizerEngine
         File.WriteAllText(Constants.ConfigYml, YamlSerializer.Serialize(config));
 
         Logger.LogInformation("Config file saved.");
-    }
-
-    private static void SaveSessionData()
-    {
-        if (CurrentSessionData is null || CurrentSessionDataDirectoryPath is null)
-        {
-            return;
-        }
-
-        Logger.LogInformation("Saving the session data into file...");
-        
-        File.WriteAllText(Path.Combine(CurrentSessionDataDirectoryPath, Constants.SessionYml), YamlSerializer.Serialize(CurrentSessionData));
-
-        Logger.LogInformation("Session data saved.");
     }
 
     /// <summary>
@@ -658,248 +471,22 @@ public static partial class RandomizerEngine
     }
 
     /// <summary>
-    /// Starts the randomizer session by creating a new watch and <see cref="Task"/> for <see cref="CurrentSession"/> (+ <see cref="CurrentSessionTokenSource"/>) that will handle randomization on different thread from the UI thread.
+    /// Starts the randomizer session by creating a new <see cref="Session"/> that will handle randomization on different thread from the UI thread.
     /// </summary>
-    public static Task StartSessionAsync()
+    public static void StartSession()
     {
         if (Config.GameDirectory is null)
         {
-            return Task.CompletedTask;
+            return;
         }
 
-        CurrentSessionWatch = new Stopwatch();
-        CurrentSessionTokenSource = new CancellationTokenSource();
-        CurrentSession = Task.Run(() => RunSessionSafeAsync(CurrentSessionTokenSource.Token), CurrentSessionTokenSource.Token);
-
-        return Task.CompletedTask;
-    }
-
-    /// <summary>
-    /// Runs the session in a way it won't ever throw an exception. Clears the session after its end as well.
-    /// </summary>
-    /// <param name="cancellationToken"></param>
-    /// <returns></returns>
-    private static async Task RunSessionSafeAsync(CancellationToken cancellationToken)
-    {
-        try
-        {
-            await RunSessionAsync(cancellationToken);
-        }
-        catch (TaskCanceledException)
-        {
-            Status("Session ended.");
-        }
-        catch (InvalidSessionException)
-        {
-            Status("Session ended. No maps found.");
-        }
-        catch (Exception ex)
-        {
-            Status("Session ended due to error.");
-            Logger.LogError(ex, "Error during session.");
-        }
-        finally
-        {
-            ClearCurrentSession();
-        }
-    }
-
-    /// <summary>
-    /// Does the actual work during a running session. That this method ends means the session also ends. It does NOT clean up the session after its end.
-    /// </summary>
-    /// <param name="cancellationToken"></param>
-    /// <returns></returns>
-    /// <exception cref="TaskCanceledException"></exception>
-    private static async Task RunSessionAsync(CancellationToken cancellationToken)
-    {
-        if (Config.GameDirectory is null)
-        {
-            throw new UnreachableException("Game directory is null");
-        }
-
-        ValidateRules();
-
-        InitializeSessionData();
-
-        while (true)
-        {
-            // This try block is used to handle map requests and their HTTP errors, mostly.
-
-            try
-            {
-                await PrepareNewMapAsync(cancellationToken);
-            }
-            catch (HttpRequestException)
-            {
-                Status("Failed to fetch a track. Retrying...");
-                await Task.Delay(1000, cancellationToken);
-                continue;
-            }
-            catch (MapValidationException)
-            {
-                Logger.LogInformation("Map has not passed the validator, attempting another one...");
-                await Task.Delay(500, cancellationToken);
-                continue;
-            }
-            catch (InvalidSessionException)
-            {
-                Logger.LogWarning("Session is invalid.");
-                throw;
-            }
-            catch (TaskCanceledException)
-            {
-                Logger.LogInformation("Session terminated during map request.");
-                throw;
-            }
-            catch (Exception ex)
-            {
-                Status("Error! Check the log for more details.");
-                Logger.LogError(ex, "An error occurred during map request.");
-
-                await Task.Delay(1000, cancellationToken);
-
-                continue;
-            }
-
-            await PlayCurrentSessionMapAsync(cancellationToken);
-        }
-    }
-
-    private static void InitializeSessionData()
-    {
-        var startedAt = DateTimeOffset.Now;
-
-        CurrentSessionData = new SessionData(Version, startedAt, Config.Rules);
-
-        if (CurrentSessionDataDirectoryPath is null)
-        {
-            throw new UnreachableException("CurrentSessionDataDirectoryPath is null");
-        }
-
-        Directory.CreateDirectory(CurrentSessionDataDirectoryPath);
-
-        CurrentSessionLogWriter = new StreamWriter(Path.Combine(CurrentSessionDataDirectoryPath, Constants.SessionLog))
-        {
-            AutoFlush = true
-        };
-
-        Logger = new LoggerToFile(CurrentSessionLogWriter, LogWriter);
-
-        SaveSessionData();
-    }
-
-    /// <summary>
-    /// Validates the session rules. This should be called right before the session start and after loading the modules.
-    /// </summary>
-    /// <exception cref="RuleValidationException"></exception>
-    public static void ValidateRules()
-    {
-        if (Config.Rules.TimeLimit == TimeSpan.Zero)
-        {
-            throw new RuleValidationException("Time limit cannot be 0:00:00.");
-        }
-
-        if (Config.Rules.TimeLimit > new TimeSpan(9, 59, 59))
-        {
-            throw new RuleValidationException("Time limit cannot be above 9:59:59.");
-        }
-
-        foreach (var primaryType in Enum.GetValues<EPrimaryType>())
-        {
-            if (primaryType is EPrimaryType.Race)
-            {
-                continue;
-            }
-
-            if (Config.Rules.RequestRules.PrimaryType == primaryType
-            && (Config.Rules.RequestRules.Site is ESite.Any
-             || Config.Rules.RequestRules.Site.HasFlag(ESite.TMNF) || Config.Rules.RequestRules.Site.HasFlag(ESite.Nations)))
-            {
-                throw new RuleValidationException($"{primaryType} cannot be specifically selected with TMNF or Nations Exchange.");
-            }
-        }
-
-        if (Config.Rules.RequestRules.Environment?.Count > 0)
-        {
-            if (Config.Rules.RequestRules.Site.HasFlag(ESite.Sunrise)
-            && !Config.Rules.RequestRules.Environment.Contains(EEnvironment.Island)
-            && !Config.Rules.RequestRules.Environment.Contains(EEnvironment.Coast)
-            && !Config.Rules.RequestRules.Environment.Contains(EEnvironment.Bay))
-            {
-                throw new RuleValidationException("Island, Coast, or Bay has to be selected when environments are specified and Sunrise Exchange is selected.");
-            }
-
-            if (Config.Rules.RequestRules.Site.HasFlag(ESite.Original)
-            && !Config.Rules.RequestRules.Environment.Contains(EEnvironment.Snow)
-            && !Config.Rules.RequestRules.Environment.Contains(EEnvironment.Desert)
-            && !Config.Rules.RequestRules.Environment.Contains(EEnvironment.Rally))
-            {
-                throw new RuleValidationException("Snow, Desert, or Rally has to be selected when environments are specified and Original Exchange is selected.");
-            }
-
-            if (!Config.Rules.RequestRules.Environment.Contains(EEnvironment.Stadium)
-             && (Config.Rules.RequestRules.Site.HasFlag(ESite.TMNF) || Config.Rules.RequestRules.Site.HasFlag(ESite.Nations)))
-            {
-                throw new RuleValidationException("Stadium has to be selected when environments are specified and TMNF or Nations Exchange is selected.");
-            }
-
-            if (Config.Rules.RequestRules.Site.HasFlag(ESite.Sunrise) || Config.Rules.RequestRules.Site.HasFlag(ESite.Original))
-            {
-                foreach (var env in Config.Rules.RequestRules.Environment)
-                {
-                    if (Config.Rules.RequestRules.Vehicle?.Contains(env) == false)
-                    {
-                        throw new RuleValidationException("Envimix randomization is not allowed when Sunrise or Original Exchange is selected.");
-                    }
-                }
-            }
-        }
-        
-        if (Config.Rules.RequestRules.Vehicle?.Count > 0)
-        {
-            if (!Config.Rules.RequestRules.Vehicle.Contains(EEnvironment.Island)
-             && !Config.Rules.RequestRules.Vehicle.Contains(EEnvironment.Coast)
-             && !Config.Rules.RequestRules.Vehicle.Contains(EEnvironment.Bay)
-              && Config.Rules.RequestRules.Site.HasFlag(ESite.Sunrise))
-            {
-                throw new RuleValidationException("IslandCar, CoastCar, or BayCar has to be selected when cars are specified and Sunrise Exchange is selected.");
-            }
-
-            if (!Config.Rules.RequestRules.Vehicle.Contains(EEnvironment.Snow)
-             && !Config.Rules.RequestRules.Vehicle.Contains(EEnvironment.Desert)
-             && !Config.Rules.RequestRules.Vehicle.Contains(EEnvironment.Rally)
-              && Config.Rules.RequestRules.Site.HasFlag(ESite.Original))
-            {
-                throw new RuleValidationException("SnowCar, DesertCar, or RallyCar has to be selected when cars are specified and Original Exchange is selected.");
-            }
-
-            if (!Config.Rules.RequestRules.Vehicle.Contains(EEnvironment.Stadium)
-             && (Config.Rules.RequestRules.Site.HasFlag(ESite.TMNF) || Config.Rules.RequestRules.Site.HasFlag(ESite.Nations)))
-            {
-                throw new RuleValidationException("StadiumCar has to be selected when cars are specified and TMNF or Nations Exchange is selected.");
-            }
-        }
-
-        if (Config.Rules.RequestRules.EqualEnvironmentDistribution
-         && Config.Rules.RequestRules.EqualVehicleDistribution
-         && Config.Rules.RequestRules.Site is not ESite.TMUF)
-        {
-            throw new RuleValidationException("Equal environment and car distribution combined is only valid with TMUF Exchange.");
-        }
-
-        if (Config.Rules.RequestRules.EqualEnvironmentDistribution
-        && (Config.Rules.RequestRules.Site is ESite.Any
-         || Config.Rules.RequestRules.Site.HasFlag(ESite.TMNF) || Config.Rules.RequestRules.Site.HasFlag(ESite.Nations)))
-        {
-            throw new RuleValidationException("Equal environment distribution is not valid with TMNF or Nations Exchange.");
-        }
-
-        if (Config.Rules.RequestRules.EqualVehicleDistribution
-        && (Config.Rules.RequestRules.Site is ESite.Any
-         || Config.Rules.RequestRules.Site.HasFlag(ESite.TMNF) || Config.Rules.RequestRules.Site.HasFlag(ESite.Nations)))
-        {
-            throw new RuleValidationException("Equal vehicle distribution is not valid with TMNF or Nations Exchange.");
-        }
+        CurrentSession = new CurrentSession(
+            new MapDownloader(Config, Http, Logger),
+            Config,
+            new TMForever(Config, Logger),
+            Http,
+            Logger);
+        CurrentSession.Start();
     }
 
     /// <summary>
@@ -907,326 +494,10 @@ public static partial class RandomizerEngine
     /// </summary>
     private static void ClearCurrentSession()
     {
-        StopTrackingCurrentSessionMap();
-
-        CurrentSessionGoldMaps.Clear();
-        CurrentSessionAuthorMaps.Clear();
-        CurrentSessionSkippedMaps.Clear();
-
-        CurrentSessionWatch?.Stop();
-        CurrentSessionWatch = null;
-
+        CurrentSession?.Stop();
         CurrentSession = null;
-        CurrentSessionTokenSource = null;
-        
-        SetReadOnlySessionYml();
-
-        CurrentSessionData = null;
-
-        CurrentSessionLogWriter?.Dispose();
-        CurrentSessionLogWriter = null;
 
         Logger = new LoggerToFile(LogWriter);
-    }
-
-    private static void SetReadOnlySessionYml()
-    {
-        if (CurrentSessionDataDirectoryPath is null)
-        {
-            return;
-        }
-        
-        try
-        {
-            var sessionYmlFile = Path.Combine(CurrentSessionDataDirectoryPath, Constants.SessionYml);
-            File.SetAttributes(sessionYmlFile, File.GetAttributes(sessionYmlFile) | FileAttributes.ReadOnly);
-        }
-        catch (Exception ex)
-        {
-            Logger.LogError(ex, "Failed to set Session.yml as read-only.");
-        }
-    }
-
-    /// <summary>
-    /// Requests, downloads, and allocates the map.
-    /// </summary>
-    /// <param name="cancellationToken"></param>
-    /// <exception cref="InvalidSessionException"></exception>
-    /// <exception cref="MapValidationException"></exception>
-    private static async Task PrepareNewMapAsync(CancellationToken cancellationToken)
-    {
-        Status("Fetching random track...");
-        
-        // Randomized URL is constructed with the ToUrl() method.
-        var requestUrl = Config.Rules.RequestRules.ToUrl();
-
-        Logger.LogDebug("Requesting generated URL: {url}", requestUrl);
-
-        // HEAD request ensures least overhead
-        using var randomResponse = await Http.HeadAsync(requestUrl, cancellationToken);
-
-        if (randomResponse.StatusCode == HttpStatusCode.NotFound)
-        {
-            // The session is ALWAYS invalid if there's no map that can be found.
-            // This DOES NOT relate to the lack of maps left that the user hasn't played.
-
-            Logger.LogWarning("No map fulfills the randomization filter.");
-
-            throw new InvalidSessionException();
-        }
-
-        randomResponse.EnsureSuccessStatusCode(); // Handles server issues, should normally retry
-
-
-        // Following code gathers the track ID from the HEAD response (and ensures everything makes sense)
-
-        if (randomResponse.RequestMessage is null)
-        {
-            Logger.LogWarning("Response from the HEAD request does not contain information about the request message. This is odd...");
-            return;
-        }
-
-        if (randomResponse.RequestMessage.RequestUri is null)
-        {
-            Logger.LogWarning("Response from the HEAD request does not contain information about the request URI. This is odd...");
-            return;
-        }
-
-        var trackId = randomResponse.RequestMessage.RequestUri.Segments.LastOrDefault();
-
-        if (trackId is null)
-        {
-            Logger.LogWarning("Request URI does not contain any segments. This is very odd...");
-            return;
-        }
-
-
-        // With the ID, it is possible to immediately download the track Gbx and process it with GBX.NET
-
-        Status($"Downloading track {trackId}...");
-
-        var trackGbxUrl = $"https://{randomResponse.RequestMessage.RequestUri.Host}/trackgbx/{trackId}";
-
-        Logger.LogDebug("Downloading track on {trackGbxUrl}...", trackGbxUrl);
-        using var trackGbxResponse = await Http.GetAsync(trackGbxUrl, cancellationToken);
-        trackGbxResponse.EnsureSuccessStatusCode();
-
-        using var stream = await trackGbxResponse.Content.ReadAsStreamAsync(cancellationToken);
-
-
-        // The map is gonna be parsed as it is downloading throughout
-
-        Status("Parsing the map...");
-
-        if (GameBox.ParseNode(stream) is not CGameCtnChallenge map)
-        {
-            Logger.LogWarning("Downloaded file is not a valid Gbx map file!");
-            return;
-        }
-
-
-        // Map validation ensures that the player won't receive duplicate maps
-        // + ensures some additional filters like "No Unlimiter", which cannot be filtered on TMX
-
-        Status("Validating the map...");
-
-        if (!ValidateMap(map, out string? invalidBlock))
-        {
-            // Attempts another track if invalid
-            requestAttempt++;
-
-            if (invalidBlock is not null)
-            {
-                Status($"{invalidBlock} in {map.Collection}");
-                Logger.LogInformation("Map is invalid because {invalidBlock} is not valid for the {env} environment.", invalidBlock, map.Collection);
-                await Task.Delay(500, cancellationToken);
-            }
-
-            Status($"Map is invalid (attempt {requestAttempt}/{requestMaxAttempts}).");
-
-            if (requestAttempt >= requestMaxAttempts)
-            {
-                Logger.LogWarning("Map is invalid after {MaxAttempts} attempts. Cancelling the session...", requestMaxAttempts);
-                requestAttempt = 0;
-                throw new InvalidSessionException();
-            }
-
-            throw new MapValidationException();
-        }
-
-        requestAttempt = 0;
-
-        // The map is saved to the defined DownloadedDirectoryPath using the FileName provided in ContentDisposition
-
-        Status("Saving the map...");
-
-        if (DownloadedDirectoryPath is null)
-        {
-            throw new UnreachableException("Cannot update autosaves without a valid user data directory path.");
-        }
-
-        Logger.LogDebug("Ensuring {dir} exists...", DownloadedDirectoryPath);
-        Directory.CreateDirectory(DownloadedDirectoryPath); // Ensures the directory really exists
-
-        Logger.LogDebug("Preparing the file name...");
-
-        // Extracts the file name, and if it fails, it uses the MapUid as a fallback
-        var fileName = trackGbxResponse.Content.Headers.ContentDisposition?.FileName?.Trim('\"') ?? $"{map.MapUid}.Challenge.Gbx";
-
-        // Validates the file name and fixes it if needed
-        fileName = ClearFileName(fileName);
-
-        CurrentSessionMapSavePath = Path.Combine(DownloadedDirectoryPath, fileName);
-
-        Logger.LogInformation("Saving the map as {fileName}...", CurrentSessionMapSavePath);
-
-        // WriteAllBytesAsync is used instead of GameBox.Save to ensure 1:1 data of the original map
-        var trackData = await trackGbxResponse.Content.ReadAsByteArrayAsync(cancellationToken);
-
-        await File.WriteAllBytesAsync(CurrentSessionMapSavePath, trackData, cancellationToken);
-
-        Logger.LogInformation("Map saved successfully!");
-
-        var tmxLink = randomResponse.RequestMessage.RequestUri.ToString();
-
-        CurrentSessionMap = new SessionMap(map, randomResponse.Headers.Date ?? DateTimeOffset.Now, tmxLink); // The map should be ready to be played now
-
-        CurrentSessionData?.Maps.Add(new()
-        {
-            Name = TextFormatter.Deformat(map.MapName),
-            Uid = map.MapUid,
-            TmxLink = tmxLink
-        });
-
-        SaveSessionData(); // May not be super necessary?
-    }
-
-
-
-    /// <summary>
-    /// Handles the play loop of a map. Throws cancellation exception on session end (not the map end).
-    /// </summary>
-    /// <exception cref="TaskCanceledException"></exception>
-    private static async Task PlayCurrentSessionMapAsync(CancellationToken cancellationToken)
-    {
-        // Hacky last moment validations
-
-        if (CurrentSessionMapSavePath is null)
-        {
-            throw new UnreachableException("CurrentSessionMapSavePath is null");
-        }
-
-        if (CurrentSessionMap is null)
-        {
-            throw new UnreachableException("CurrentSessionMap is null");
-        }
-
-        if (CurrentSessionWatch is null)
-        {
-            throw new UnreachableException("CurrentSessionWatch is null");
-        }
-
-        // Map starts here
-
-        Status("Starting the map...");
-
-        OpenFileIngame(CurrentSessionMapSavePath);
-
-        CurrentSessionWatch.Start();
-
-        SkipTokenSource = new CancellationTokenSource();
-        MapStarted?.Invoke();
-
-        Status("Playing the map...");
-
-        // This loop either softly stops when the map is skipped by the player
-        // or hardly stops when author medal is received / time limit is reached, End Session was clicked or an exception was thrown in general
-
-        // SkipTokenSource is used within the session to skip a map, while CurrentSessionTokenSource handles the whole session cancellation
-
-        while (!SkipTokenSource.IsCancellationRequested)
-        {
-            if (CurrentSessionWatch.Elapsed >= Config.Rules.TimeLimit) // Time limit reached case
-            {
-                if (CurrentSessionTokenSource is null)
-                {
-                    throw new UnreachableException("CurrentSessionTokenSource is null");
-                }
-
-                // Will cause the Task.Delay below to throw a cancellation exception
-                // Code outside of the while loop wont be reached
-                CurrentSessionTokenSource.Cancel();
-            }
-
-            await Task.Delay(20, cancellationToken);
-        }
-
-        CurrentSessionWatch.Stop(); // Time is paused until the next map starts
-
-        if (isActualSkipCancellation) // When its a manual skip and not an automated skip by author medal receive
-        {
-            Status("Skipping the map...");
-
-            // Apply the rules related to manual map skip
-            // This part has a scripting potential too if properly implmented
-
-            Skipped(CurrentSessionMap);
-
-            isActualSkipCancellation = false;
-        }
-
-        Status("Ending the map...");
-
-        StopTrackingCurrentSessionMap();
-
-        // Map is no longer tracked at this point
-    }
-
-    /// <summary>
-    /// Checks if the map hasn't been already played or if it follows current session rules.
-    /// </summary>
-    /// <param name="map"></param>
-    /// <returns>True if valid, false if not valid.</returns>
-    private static bool ValidateMap(CGameCtnChallenge map, out string? invalidBlock)
-    {
-        invalidBlock = null;
-
-        if (AutosaveHeaders.ContainsKey(map.MapUid))
-        {
-            return false;
-        }
-
-        if (Config.Rules.NoUnlimiter)
-        {
-            if (map.Chunks.TryGet(0x3F001000, out _))
-            {
-                return false;
-            }
-            
-            if (OfficialBlocks.TryGetValue(map.Collection, out var officialBlocks))
-            {
-                foreach (var block in map.GetBlocks())
-                {
-                    var blockName = block.Name.Trim();
-
-                    if (!officialBlocks.Contains(blockName))
-                    {
-                        invalidBlock = blockName;
-                        return false;
-                    }
-                }
-            }
-        }
-
-        return true;
-    }
-
-    private static void StopTrackingCurrentSessionMap()
-    {
-        SkipTokenSource = null;
-        CurrentSessionMap = null;
-        CurrentSessionMapSavePath = null;
-        MapEnded?.Invoke();
     }
 
     /// <summary>
@@ -1244,16 +515,19 @@ public static partial class RandomizerEngine
 
         Status("Ending the session...");
 
-        CurrentSessionTokenSource?.Cancel();
-
         if (CurrentSession is null)
         {
             return;
         }
 
+        CurrentSession.TokenSource.Cancel();
+
         try
         {
-            await CurrentSession; // Kindly waits until the session considers it was cancelled. ClearCurrentSession is called within it.
+            if (CurrentSession.Task is not null)
+            {
+                await CurrentSession.Task; // Kindly waits until the session considers it was cancelled. ClearCurrentSession is called within it.
+            }
         }
         catch (TaskCanceledException)
         {
@@ -1263,70 +537,11 @@ public static partial class RandomizerEngine
         SessionEnding = false;
     }
 
-    public static Task SkipMapAsync()
-    {
-        Status("Requested to skip the map...");
-        isActualSkipCancellation = true;
-        SkipTokenSource?.Cancel();
-        return Task.CompletedTask;
-    }
-
-    public static void OpenFileIngame(string filePath)
-    {
-        if (Config.GameDirectory is null)
-        {
-            throw new Exception("Game directory is null");
-        }
-
-        Logger.LogInformation("Opening {filePath} in TMForever...", filePath);
-
-        var startInfo = new ProcessStartInfo(Path.Combine(Config.GameDirectory, Constants.TmForeverExe), $"/useexedir /singleinst /file=\"{filePath}\"")
-        {
-            
-        };
-        
-        var process = new Process
-        {
-            StartInfo = startInfo
-        };
-        
-        process.Start();
-        
-        try
-        {
-            process.WaitForInputIdle();
-        }
-        catch (InvalidOperationException ex)
-        {
-            Logger.LogWarning(ex, "Could not wait for input.");
-        }
-    }
-
-    public static void OpenAutosaveIngame(string fileName)
-    {
-        if (AutosavesDirectoryPath is null)
-        {
-            throw new Exception("Cannot open an autosave ingame without a valid user data directory path.");
-        }
-
-        OpenFileIngame(Path.Combine(AutosavesDirectoryPath, fileName));
-    }
-
     public static void Exit()
     {
         Logger.LogInformation("Exiting...");
         FlushLog();
         Environment.Exit(0);
-    }
-
-    public static void ReloadMap()
-    {
-        Logger.LogInformation("Reloading the map...");
-
-        if (CurrentSessionMapSavePath is not null)
-        {
-            OpenFileIngame(CurrentSessionMapSavePath);
-        }
     }
 
     public static void FlushLog()

--- a/Src/RandomizerTMF.Logic/RandomizerEngine.cs
+++ b/Src/RandomizerTMF.Logic/RandomizerEngine.cs
@@ -4,7 +4,6 @@ using GBX.NET.Exceptions;
 using Microsoft.Extensions.Logging;
 using RandomizerTMF.Logic.Exceptions;
 using RandomizerTMF.Logic.TypeConverters;
-using System.Collections.Concurrent;
 using System.Diagnostics;
 using TmEssentials;
 using YamlDotNet.Serialization;
@@ -12,10 +11,7 @@ using YamlDotNet.Serialization;
 namespace RandomizerTMF.Logic;
 
 public static partial class RandomizerEngine
-{
-    private static string? userDataDirectoryPath;
-    private static bool hasAutosavesScanned;
-    
+{    
     public static ISerializer YamlSerializer { get; } = new SerializerBuilder()
         .WithTypeConverter(new DateOnlyConverter())
         .WithTypeConverter(new DateTimeOffsetConverter())
@@ -37,51 +33,10 @@ public static partial class RandomizerEngine
     public static string? TmForeverExeFilePath { get; set; }
     public static string? TmUnlimiterExeFilePath { get; set; }
 
-    /// <summary>
-    /// General directory of the user data. It also sets the <see cref="AutosavesDirectoryPath"/>, <see cref="DownloadedDirectoryPath"/>, and <see cref="AutosaveWatcher"/> path with it.
-    /// </summary>
-    public static string? UserDataDirectoryPath
-    {
-        get => userDataDirectoryPath;
-        set
-        {
-            userDataDirectoryPath = value;
-
-            AutosavesDirectoryPath = userDataDirectoryPath is null ? null : Path.Combine(userDataDirectoryPath, Constants.Tracks, Constants.Replays, Constants.Autosaves);
-            DownloadedDirectoryPath = userDataDirectoryPath is null ? null : Path.Combine(userDataDirectoryPath, Constants.Tracks, Constants.Challenges, Constants.Downloaded, string.IsNullOrWhiteSpace(Config.DownloadedMapsDirectory) ? Constants.DownloadedMapsDirectory : Config.DownloadedMapsDirectory);
-
-            AutosaveWatcher.Path = AutosavesDirectoryPath ?? "";
-        }
-    }
-
-    public static string? AutosavesDirectoryPath { get; private set; }
-    public static string? DownloadedDirectoryPath { get; private set; }
-    public static string SessionsDirectoryPath => Constants.Sessions;
-
     public static Session? CurrentSession { get; private set; }
     
     public static bool HasSessionRunning => CurrentSession is not null;
-
-    /// <summary>
-    /// If the map UIDs of the autosaves have been fully stored to the <see cref="AutosaveHeaders"/> and <see cref="AutosavePaths"/> dictionaries.
-    /// This property is required to be true in order to start a new session. It also handles the state of <see cref="AutosaveWatcher"/>, to catch other autosaves that might be created while the program is running.
-    /// </summary>
-    public static bool HasAutosavesScanned
-    {
-        get => hasAutosavesScanned;
-        private set
-        {
-            hasAutosavesScanned = value;
-            AutosaveWatcher.EnableRaisingEvents = value;
-        }
-    }
-
-    public static ConcurrentDictionary<string, AutosaveHeader> AutosaveHeaders { get; } = new();
-    public static ConcurrentDictionary<string, AutosaveDetails> AutosaveDetails { get; } = new();
-
-    public static FileSystemWatcher AutosaveWatcher { get; }
-
-
+    
     public static ILogger Logger { get; private set; }
     public static StreamWriter LogWriter { get; private set; }
     public static bool SessionEnding { get; private set; }
@@ -105,7 +60,7 @@ public static partial class RandomizerEngine
         
         Logger.LogInformation("Starting Randomizer Engine...");
 
-        Directory.CreateDirectory(SessionsDirectoryPath);
+        Directory.CreateDirectory(FilePathManager.SessionsDirectoryPath);
         
         Logger.LogInformation("Predefining LZO algorithm...");
 
@@ -128,16 +83,6 @@ public static partial class RandomizerEngine
         
         Http = new HttpClient(socketHandler);
         Http.DefaultRequestHeaders.UserAgent.TryParseAdd($"Randomizer TMF {Version}");
-
-        Logger.LogInformation("Preparing general events...");
-
-        AutosaveWatcher = new FileSystemWatcher
-        {
-            NotifyFilter = NotifyFilters.FileName | NotifyFilters.LastWrite,
-            Filter = "*.Replay.gbx"
-        };
-
-        AutosaveWatcher.Changed += AutosaveCreatedOrChanged;
         
         Logger.LogInformation("Randomizer TMF initialized.");
     }
@@ -155,78 +100,6 @@ public static partial class RandomizerEngine
     public static void OnMapEnded() => MapEnded?.Invoke();
     public static void OnMapSkip() => MapSkip?.Invoke();
     public static void OnMedalUpdate() => MedalUpdate?.Invoke();
-
-    private static DateTime lastAutosaveUpdate = DateTime.MinValue;
-
-    private static void AutosaveCreatedOrChanged(object sender, FileSystemEventArgs e)
-    {
-        // Hack to fix the issue of this event sometimes running twice
-        var lastWriteTime = File.GetLastWriteTime(e.FullPath);
-
-        if (lastWriteTime == lastAutosaveUpdate)
-        {
-            return;
-        }
-        
-        lastAutosaveUpdate = lastWriteTime;
-        //
-
-        var retryCounter = 0;
-        
-        CGameCtnReplayRecord replay;
-
-        while (true)
-        {
-            try
-            {
-                // Any kind of autosave update section
-
-                Logger.LogInformation("Analyzing a new file {autosavePath} in autosaves folder...", e.FullPath);
-
-                if (GameBox.ParseNode(e.FullPath) is not CGameCtnReplayRecord r)
-                {
-                    Logger.LogWarning("Found file {file} that is not a replay.", e.FullPath);
-                    return;
-                }
-
-                if (r.MapInfo is null)
-                {
-                    Logger.LogWarning("Found replay {file} that has no map info.", e.FullPath);
-                    return;
-                }
-
-                AutosaveHeaders.TryAdd(r.MapInfo.Id, new AutosaveHeader(Path.GetFileName(e.FullPath), r));
-
-                replay = r;
-            }
-            catch (Exception ex)
-            {
-                retryCounter++;
-                
-                Logger.LogError(ex, "Error while analyzing a new file {autosavePath} in autosaves folder (retry {counter}/{maxRetries}).",
-                    e.FullPath, retryCounter, Config.ReplayParseFailRetries);
-
-                if (retryCounter >= Config.ReplayParseFailRetries)
-                {
-                    return;
-                }
-
-                Thread.Sleep(Config.ReplayParseFailDelayMs);
-
-                continue;
-            }
-
-            break;
-        }
-
-        if (CurrentSession is null)
-        {
-            Logger.LogInformation("No session is running, ending here.");
-            return;
-        }
-
-        CurrentSession.AutosaveCreatedOrChanged(e.FullPath, replay);
-    }
 
     /// <summary>
     /// This method should be ran only at the start of the randomizer engine.
@@ -286,11 +159,11 @@ public static partial class RandomizerEngine
             var myDocuments = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
             var newUserDataDirectoryPath = Path.Combine(myDocuments, nadeoIni.UserSubDir);
 
-            if (UserDataDirectoryPath != newUserDataDirectoryPath)
+            if (FilePathManager.UserDataDirectoryPath != newUserDataDirectoryPath)
             {
-                UserDataDirectoryPath = newUserDataDirectoryPath;
+                FilePathManager.UserDataDirectoryPath = newUserDataDirectoryPath;
 
-                ResetAutosaves();
+                AutosaveScanner.ResetAutosaves();
             }
         }
         catch (Exception ex)
@@ -321,16 +194,6 @@ public static partial class RandomizerEngine
         return new GameDirInspectResult(nadeoIniException, tmForeverExeException, tmUnlimiterExeException);
     }
 
-    /// <summary>
-    /// Cleans up the autosave storage and, most importantly, restricts the engine from functionalities that require the autosaves (<see cref="HasAutosavesScanned"/>).
-    /// </summary>
-    public static void ResetAutosaves()
-    {
-        AutosaveHeaders.Clear();
-        AutosaveDetails.Clear();
-        HasAutosavesScanned = false;
-    }
-
     public static void SaveConfig()
     {
         SaveConfig(Config);
@@ -343,131 +206,6 @@ public static partial class RandomizerEngine
         File.WriteAllText(Constants.ConfigYml, YamlSerializer.Serialize(config));
 
         Logger.LogInformation("Config file saved.");
-    }
-
-    /// <summary>
-    /// Scans the autosaves, which is required before running the session, to avoid already played maps.
-    /// </summary>
-    /// <returns>True if anything changed.</returns>
-    /// <exception cref="ImportantPropertyNullException"></exception>
-    public static bool ScanAutosaves()
-    {
-        if (AutosavesDirectoryPath is null)
-        {
-            throw new ImportantPropertyNullException("Cannot scan autosaves without a valid user data directory path.");
-        }
-
-        var anythingChanged = false;
-
-        foreach (var file in Directory.EnumerateFiles(AutosavesDirectoryPath).AsParallel())
-        {
-            try
-            {
-                if (GameBox.ParseNodeHeader(file) is not CGameCtnReplayRecord replay || replay.MapInfo is null)
-                {
-                    continue;
-                }
-
-                var mapUid = replay.MapInfo.Id;
-
-                if (AutosaveHeaders.ContainsKey(mapUid))
-                {
-                    continue;
-                }
-
-                AutosaveHeaders.TryAdd(mapUid, new AutosaveHeader(Path.GetFileName(file), replay));
-
-                anythingChanged = true;
-            }
-            catch (NotAGbxException)
-            {
-                // do nothing
-            }
-            catch (Exception ex)
-            {
-                Logger.LogWarning(ex, "Gbx error found in the Autosaves folder when reading the header.");
-            }
-        }
-
-        HasAutosavesScanned = true;
-
-        return anythingChanged;
-    }
-
-    /// <summary>
-    /// Scans autosave details (mostly the map inside the replay and getting its info) that are then used to display more detailed information about a list of maps. Only some replay properties are stored to value memory.
-    /// </summary>
-    /// <exception cref="Exception"></exception>
-    public static void ScanDetailsFromAutosaves()
-    {
-        if (AutosavesDirectoryPath is null)
-        {
-            throw new Exception("Cannot update autosaves without a valid user data directory path.");
-        }
-
-        foreach (var autosave in AutosaveHeaders.Keys)
-        {
-            try
-            {
-                UpdateAutosaveDetail(autosave);
-            }
-            catch (Exception ex)
-            {
-                // this happens in async context, logger may not be safe for that, some errors may get lost
-                Debug.WriteLine("Exception during autosave detail scan: " + ex);
-            }
-        }
-    }
-
-    private static void UpdateAutosaveDetail(string autosaveFileName)
-    {
-        var autosavePath = Path.Combine(AutosavesDirectoryPath!, AutosaveHeaders[autosaveFileName].FilePath); // Forgive because it's a private method
-
-        if (GameBox.ParseNode(autosavePath) is not CGameCtnReplayRecord { Time: not null } replay)
-        {
-            return;
-        }
-        
-        if (replay.Challenge is null)
-        {
-            return;
-        }
-
-        var mapName = TextFormatter.Deformat(replay.Challenge.MapName);
-        var mapEnv = (string)replay.Challenge.Collection;
-        var mapBronzeTime = replay.Challenge.TMObjective_BronzeTime ?? throw new ImportantPropertyNullException("Bronze time is null.");
-        var mapSilverTime = replay.Challenge.TMObjective_SilverTime ?? throw new ImportantPropertyNullException("Silver time is null.");
-        var mapGoldTime = replay.Challenge.TMObjective_GoldTime ?? throw new ImportantPropertyNullException("Gold time is null.");
-        var mapAuthorTime = replay.Challenge.TMObjective_AuthorTime ?? throw new ImportantPropertyNullException("Author time is null.");
-        var mapAuthorScore = replay.Challenge.AuthorScore ?? throw new ImportantPropertyNullException("AuthorScore is null.");
-        var mapMode = replay.Challenge.Mode;
-        var mapCarPure = replay.Challenge.PlayerModel?.Id;
-        var mapCar = string.IsNullOrEmpty(mapCarPure) ? $"{mapEnv}Car" : mapCarPure;
-
-        mapCar = mapCar switch
-        {
-            Constants.AlpineCar => Constants.SnowCar,
-            Constants.American or Constants.SpeedCar => Constants.DesertCar,
-            Constants.Rally => Constants.RallyCar,
-            Constants.SportCar => Constants.IslandCar,
-            _ => mapCar
-        };
-
-        var ghost = replay.GetGhosts().FirstOrDefault();
-
-        AutosaveDetails[autosaveFileName] = new(
-            replay.Time.Value,
-            Score: ghost?.StuntScore,
-            Respawns: ghost?.Respawns,
-            mapName,
-            mapEnv,
-            mapCar,
-            mapBronzeTime,
-            mapSilverTime,
-            mapGoldTime,
-            mapAuthorTime,
-            mapAuthorScore,
-            mapMode);
     }
 
     /// <summary>
@@ -513,7 +251,7 @@ public static partial class RandomizerEngine
 
         SessionEnding = true;
 
-        Status("Ending the session...");
+        OnStatus("Ending the session...");
 
         if (CurrentSession is null)
         {

--- a/Src/RandomizerTMF.Logic/Session.cs
+++ b/Src/RandomizerTMF.Logic/Session.cs
@@ -1,16 +1,13 @@
-﻿using GBX.NET;
-using GBX.NET.Engines.Game;
+﻿using GBX.NET.Engines.Game;
 using Microsoft.Extensions.Logging;
 using RandomizerTMF.Logic.Exceptions;
 using System.Collections.Immutable;
 using System.Diagnostics;
-using System.Net;
 using TmEssentials;
-using static GBX.NET.Engines.Game.CGameGhost;
 
 namespace RandomizerTMF.Logic;
 
-public class CurrentSession
+public class Session
 {
     private readonly MapDownloader mapDownloader;
     private readonly RandomizerConfig config;
@@ -39,7 +36,7 @@ public class CurrentSession
     
     public StreamWriter? LogWriter { get; set; }
 
-    public CurrentSession(MapDownloader mapDownloader,
+    public Session(MapDownloader mapDownloader,
                           RandomizerConfig config,
                           TMForever game,
                           HttpClient http,

--- a/Src/RandomizerTMF.Logic/Session.cs
+++ b/Src/RandomizerTMF.Logic/Session.cs
@@ -37,10 +37,10 @@ public class Session
     public StreamWriter? LogWriter { get; set; }
 
     public Session(MapDownloader mapDownloader,
-                          RandomizerConfig config,
-                          TMForever game,
-                          HttpClient http,
-                          ILogger logger)
+                   RandomizerConfig config,
+                   TMForever game,
+                   HttpClient http,
+                   ILogger logger)
     {
         this.mapDownloader = mapDownloader;
         this.config = config;

--- a/Src/RandomizerTMF.Logic/Session.cs
+++ b/Src/RandomizerTMF.Logic/Session.cs
@@ -167,12 +167,12 @@ public class Session
 
         if (Map is null)
         {
-            throw new UnreachableException("CurrentSessionMap is null");
+            throw new UnreachableException("Map is null");
         }
 
         if (Map.FilePath is null)
         {
-            throw new UnreachableException("CurrentSessionMapSavePath is null");
+            throw new UnreachableException("Map.FilePath is null");
         }
 
         // Map starts here

--- a/Src/RandomizerTMF.Logic/SessionData.cs
+++ b/Src/RandomizerTMF.Logic/SessionData.cs
@@ -1,27 +1,127 @@
-﻿using YamlDotNet.Serialization;
+﻿using GBX.NET.Engines.Game;
+using Microsoft.Extensions.Logging;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using TmEssentials;
+using YamlDotNet.Serialization;
+using static GBX.NET.Engines.Game.CGameGhost;
 
 namespace RandomizerTMF.Logic;
 
 public class SessionData
 {
+    private readonly RandomizerConfig config;
+    private readonly ILogger? logger;
+
     public string? Version { get; set; }
     public DateTimeOffset StartedAt { get; set; }
     public RandomizerRules Rules { get; set; }
 
     [YamlIgnore]
     public string StartedAtText => StartedAt.ToString("yyyy-MM-dd HH_mm_ss");
+    
+    [YamlIgnore]
+    public string DirectoryPath { get; }
 
     public List<SessionDataMap> Maps { get; set; } = new();
 
-    public SessionData() : this(null, DateTimeOffset.Now, new())
+    public SessionData() : this(null, DateTimeOffset.Now, new(), null)
     {
         
     }
 
-    public SessionData(string? version, DateTimeOffset startedAt, RandomizerRules rules)
+    private SessionData(string? version, DateTimeOffset startedAt, RandomizerConfig config, ILogger? logger)
     {
         Version = version;
         StartedAt = startedAt;
-        Rules = rules;
+        
+        this.config = config;
+        this.logger = logger;
+
+        Rules = config.Rules;
+
+        DirectoryPath = Path.Combine(FilePathManager.SessionsDirectoryPath, StartedAtText);
+    }
+
+    public static SessionData Initialize(RandomizerConfig config, ILogger logger)
+    {
+        var startedAt = DateTimeOffset.Now;
+
+        var data = new SessionData(RandomizerEngine.Version, startedAt, config, logger);
+
+        Directory.CreateDirectory(data.DirectoryPath);
+
+        data.Save();
+
+        return data;
+    }
+
+    public void SetMapResult(SessionMap map, string result)
+    {
+        var dataMap = Maps.FirstOrDefault(x => x.Uid == map.MapUid);
+
+        if (dataMap is not null)
+        {
+            dataMap.Result = result;
+            dataMap.LastTimestamp = map.LastTimestamp;
+        }
+
+        Save();
+    }
+
+    public void Save()
+    {
+        logger?.LogInformation("Saving the session data into file...");
+
+        File.WriteAllText(Path.Combine(DirectoryPath, Constants.SessionYml), RandomizerEngine.YamlSerializer.Serialize(this));
+
+        logger?.LogInformation("Session data saved.");
+    }
+
+    public void SetReadOnlySessionYml()
+    {
+        try
+        {
+            var sessionYmlFile = Path.Combine(DirectoryPath, Constants.SessionYml);
+            File.SetAttributes(sessionYmlFile, File.GetAttributes(sessionYmlFile) | FileAttributes.ReadOnly);
+        }
+        catch (Exception ex)
+        {
+            logger?.LogError(ex, "Failed to set Session.yml as read-only.");
+        }
+    }
+
+    public void UpdateFromAutosave(string fullPath, SessionMap map, CGameCtnReplayRecord replay, TimeSpan elapsed)
+    {
+        var score = map.Map.Mode switch
+        {
+            CGameCtnChallenge.PlayMode.Stunts => replay.GetGhosts().First().StuntScore + "_",
+            CGameCtnChallenge.PlayMode.Platform => replay.GetGhosts().First().Respawns + "_",
+            _ => ""
+        } + replay.Time.ToTmString(useHundredths: true, useApostrophe: true);
+
+        var mapName = CompiledRegex.SpecialCharRegex().Replace(TextFormatter.Deformat(map.Map.MapName).Trim(), "_");
+
+        var replayFileFormat = string.IsNullOrWhiteSpace(config.ReplayFileFormat)
+            ? Constants.DefaultReplayFileFormat
+            : config.ReplayFileFormat;
+
+        var replayFileName = FilePathManager.ClearFileName(string.Format(replayFileFormat, mapName, score, replay.PlayerLogin));
+
+        var replaysDir = Path.Combine(DirectoryPath, Constants.Replays);
+        var replayFilePath = Path.Combine(replaysDir, replayFileName);
+
+        Directory.CreateDirectory(replaysDir);
+        File.Copy(fullPath, replayFilePath, overwrite: true);
+
+        Maps.FirstOrDefault(x => x.Uid == map.MapUid)?
+            .Replays
+            .Add(new()
+            {
+                FileName = replayFileName,
+                Timestamp = elapsed
+            });
+
+        Save();
     }
 }

--- a/Src/RandomizerTMF.Logic/SessionData.cs
+++ b/Src/RandomizerTMF.Logic/SessionData.cs
@@ -73,7 +73,7 @@ public class SessionData
     {
         logger?.LogInformation("Saving the session data into file...");
 
-        File.WriteAllText(Path.Combine(DirectoryPath, Constants.SessionYml), RandomizerEngine.YamlSerializer.Serialize(this));
+        File.WriteAllText(Path.Combine(DirectoryPath, Constants.SessionYml), Yaml.Serializer.Serialize(this));
 
         logger?.LogInformation("Session data saved.");
     }

--- a/Src/RandomizerTMF.Logic/SessionMap.cs
+++ b/Src/RandomizerTMF.Logic/SessionMap.cs
@@ -13,6 +13,8 @@ public class SessionMap : ISessionMap
     public string TmxLink { get; }
     
     public TimeSpan? LastTimestamp { get; set; }
+    
+    public string? FilePath { get; set; }
 
     public CGameCtnChallengeParameters? ChallengeParameters => Map.ChallengeParameters;
     public CGameCtnChallenge.PlayMode? Mode => Map.Mode;

--- a/Src/RandomizerTMF.Logic/TMForever.cs
+++ b/Src/RandomizerTMF.Logic/TMForever.cs
@@ -45,13 +45,17 @@ public class TMForever
         }
     }
 
-    public void OpenAutosave(string fileName)
+    /// <summary>
+    /// Opens the autosave ingame.
+    /// </summary>
+    /// <param name="relativeFileName">File name relative to the Autosaves folder.</param>
+    public void OpenAutosave(string relativeFileName)
     {
         if (FilePathManager.AutosavesDirectoryPath is null)
         {
             throw new Exception("Cannot open an autosave ingame without a valid user data directory path.");
         }
 
-        OpenFile(Path.Combine(FilePathManager.AutosavesDirectoryPath, fileName));
+        OpenFile(Path.Combine(FilePathManager.AutosavesDirectoryPath, relativeFileName));
     }
 }

--- a/Src/RandomizerTMF.Logic/TMForever.cs
+++ b/Src/RandomizerTMF.Logic/TMForever.cs
@@ -1,0 +1,57 @@
+﻿using Microsoft.Extensions.Logging;
+using System.Diagnostics;
+
+namespace RandomizerTMF.Logic;
+
+public class TMForever
+{
+    private readonly RandomizerConfig config;
+    private readonly ILogger logger;
+
+    public TMForever(RandomizerConfig config, ILogger logger)
+    {
+        this.config = config;
+        this.logger = logger;
+    }
+
+    public void OpenFile(string filePath)
+    {
+        if (config.GameDirectory is null)
+        {
+            throw new Exception("Game directory is null");
+        }
+
+        logger.LogInformation("Opening {filePath} in TMForever...", filePath);
+
+        var startInfo = new ProcessStartInfo(Path.Combine(config.GameDirectory, Constants.TmForeverExe), $"/useexedir /singleinst /file=\"{filePath}\"")
+        {
+
+        };
+
+        var process = new Process
+        {
+            StartInfo = startInfo
+        };
+
+        process.Start();
+
+        try
+        {
+            process.WaitForInputIdle();
+        }
+        catch (InvalidOperationException ex)
+        {
+            logger.LogWarning(ex, "Could not wait for input.");
+        }
+    }
+
+    public void OpenAutosave(string fileName)
+    {
+        if (FilePathManager.AutosavesDirectoryPath is null)
+        {
+            throw new Exception("Cannot open an autosave ingame without a valid user data directory path.");
+        }
+
+        OpenFile(Path.Combine(FilePathManager.AutosavesDirectoryPath, fileName));
+    }
+}

--- a/Src/RandomizerTMF.Logic/Validator.cs
+++ b/Src/RandomizerTMF.Logic/Validator.cs
@@ -1,0 +1,165 @@
+﻿using GBX.NET.Engines.Game;
+using RandomizerTMF.Logic.Exceptions;
+
+namespace RandomizerTMF.Logic;
+
+public static class Validator
+{
+    /// <summary>
+    /// Validates the session rules. This should be called right before the session start and after loading the modules.
+    /// </summary>
+    /// <exception cref="RuleValidationException"></exception>
+    public static void ValidateRules(RandomizerRules rules)
+    {
+        if (rules.TimeLimit == TimeSpan.Zero)
+        {
+            throw new RuleValidationException("Time limit cannot be 0:00:00.");
+        }
+
+        if (rules.TimeLimit > new TimeSpan(9, 59, 59))
+        {
+            throw new RuleValidationException("Time limit cannot be above 9:59:59.");
+        }
+
+        ValidateRequestRules(rules.RequestRules);
+    }
+
+    public static void ValidateRequestRules(RequestRules requestRules)
+    {
+        foreach (var primaryType in Enum.GetValues<EPrimaryType>())
+        {
+            if (primaryType is EPrimaryType.Race)
+            {
+                continue;
+            }
+
+            if (requestRules.PrimaryType == primaryType
+            && (requestRules.Site is ESite.Any
+             || requestRules.Site.HasFlag(ESite.TMNF) || requestRules.Site.HasFlag(ESite.Nations)))
+            {
+                throw new RuleValidationException($"{primaryType} cannot be specifically selected with TMNF or Nations Exchange.");
+            }
+        }
+
+        if (requestRules.Environment?.Count > 0)
+        {
+            if (requestRules.Site.HasFlag(ESite.Sunrise)
+            && !requestRules.Environment.Contains(EEnvironment.Island)
+            && !requestRules.Environment.Contains(EEnvironment.Coast)
+            && !requestRules.Environment.Contains(EEnvironment.Bay))
+            {
+                throw new RuleValidationException("Island, Coast, or Bay has to be selected when environments are specified and Sunrise Exchange is selected.");
+            }
+
+            if (requestRules.Site.HasFlag(ESite.Original)
+            && !requestRules.Environment.Contains(EEnvironment.Snow)
+            && !requestRules.Environment.Contains(EEnvironment.Desert)
+            && !requestRules.Environment.Contains(EEnvironment.Rally))
+            {
+                throw new RuleValidationException("Snow, Desert, or Rally has to be selected when environments are specified and Original Exchange is selected.");
+            }
+
+            if (!requestRules.Environment.Contains(EEnvironment.Stadium)
+             && (requestRules.Site.HasFlag(ESite.TMNF) || requestRules.Site.HasFlag(ESite.Nations)))
+            {
+                throw new RuleValidationException("Stadium has to be selected when environments are specified and TMNF or Nations Exchange is selected.");
+            }
+
+            if (requestRules.Site.HasFlag(ESite.Sunrise) || requestRules.Site.HasFlag(ESite.Original))
+            {
+                foreach (var env in requestRules.Environment)
+                {
+                    if (requestRules.Vehicle?.Contains(env) == false)
+                    {
+                        throw new RuleValidationException("Envimix randomization is not allowed when Sunrise or Original Exchange is selected.");
+                    }
+                }
+            }
+        }
+
+        if (requestRules.Vehicle?.Count > 0)
+        {
+            if (!requestRules.Vehicle.Contains(EEnvironment.Island)
+             && !requestRules.Vehicle.Contains(EEnvironment.Coast)
+             && !requestRules.Vehicle.Contains(EEnvironment.Bay)
+              && requestRules.Site.HasFlag(ESite.Sunrise))
+            {
+                throw new RuleValidationException("IslandCar, CoastCar, or BayCar has to be selected when cars are specified and Sunrise Exchange is selected.");
+            }
+
+            if (!requestRules.Vehicle.Contains(EEnvironment.Snow)
+             && !requestRules.Vehicle.Contains(EEnvironment.Desert)
+             && !requestRules.Vehicle.Contains(EEnvironment.Rally)
+              && requestRules.Site.HasFlag(ESite.Original))
+            {
+                throw new RuleValidationException("SnowCar, DesertCar, or RallyCar has to be selected when cars are specified and Original Exchange is selected.");
+            }
+
+            if (!requestRules.Vehicle.Contains(EEnvironment.Stadium)
+             && (requestRules.Site.HasFlag(ESite.TMNF) || requestRules.Site.HasFlag(ESite.Nations)))
+            {
+                throw new RuleValidationException("StadiumCar has to be selected when cars are specified and TMNF or Nations Exchange is selected.");
+            }
+        }
+
+        if (requestRules.EqualEnvironmentDistribution
+         && requestRules.EqualVehicleDistribution
+         && requestRules.Site is not ESite.TMUF)
+        {
+            throw new RuleValidationException("Equal environment and car distribution combined is only valid with TMUF Exchange.");
+        }
+
+        if (requestRules.EqualEnvironmentDistribution
+        && (requestRules.Site is ESite.Any
+         || requestRules.Site.HasFlag(ESite.TMNF) || requestRules.Site.HasFlag(ESite.Nations)))
+        {
+            throw new RuleValidationException("Equal environment distribution is not valid with TMNF or Nations Exchange.");
+        }
+
+        if (requestRules.EqualVehicleDistribution
+        && (requestRules.Site is ESite.Any
+         || requestRules.Site.HasFlag(ESite.TMNF) || requestRules.Site.HasFlag(ESite.Nations)))
+        {
+            throw new RuleValidationException("Equal vehicle distribution is not valid with TMNF or Nations Exchange.");
+        }
+    }
+    
+    /// <summary>
+    /// Checks if the map hasn't been already played or if it follows current session rules.
+    /// </summary>
+    /// <param name="map"></param>
+    /// <returns>True if valid, false if not valid.</returns>
+    public static bool ValidateMap(RandomizerConfig config, CGameCtnChallenge map, out string? invalidBlock)
+    {
+        invalidBlock = null;
+
+        if (RandomizerEngine.AutosaveHeaders.ContainsKey(map.MapUid))
+        {
+            return false;
+        }
+
+        if (config.Rules.NoUnlimiter)
+        {
+            if (map.Chunks.TryGet(0x3F001000, out _))
+            {
+                return false;
+            }
+
+            if (RandomizerEngine.OfficialBlocks.TryGetValue(map.Collection, out var officialBlocks))
+            {
+                foreach (var block in map.GetBlocks())
+                {
+                    var blockName = block.Name.Trim();
+
+                    if (!officialBlocks.Contains(blockName))
+                    {
+                        invalidBlock = blockName;
+                        return false;
+                    }
+                }
+            }
+        }
+
+        return true;
+    }
+}

--- a/Src/RandomizerTMF.Logic/Validator.cs
+++ b/Src/RandomizerTMF.Logic/Validator.cs
@@ -133,7 +133,7 @@ public static class Validator
     {
         invalidBlock = null;
 
-        if (RandomizerEngine.AutosaveHeaders.ContainsKey(map.MapUid))
+        if (AutosaveScanner.AutosaveHeaders.ContainsKey(map.MapUid))
         {
             return false;
         }

--- a/Src/RandomizerTMF.Logic/Yaml.cs
+++ b/Src/RandomizerTMF.Logic/Yaml.cs
@@ -1,0 +1,20 @@
+﻿using RandomizerTMF.Logic.TypeConverters;
+using YamlDotNet.Serialization;
+
+namespace RandomizerTMF.Logic;
+
+public static class Yaml
+{
+    public static ISerializer Serializer { get; } = new SerializerBuilder()
+        .WithTypeConverter(new DateOnlyConverter())
+        .WithTypeConverter(new DateTimeOffsetConverter())
+        .WithTypeConverter(new TimeInt32Converter())
+        .Build();
+
+    public static IDeserializer Deserializer { get; } = new DeserializerBuilder()
+        .WithTypeConverter(new DateOnlyConverter())
+        .WithTypeConverter(new DateTimeOffsetConverter())
+        .WithTypeConverter(new TimeInt32Converter())
+        .IgnoreUnmatchedProperties()
+        .Build();
+}

--- a/Src/RandomizerTMF/App.axaml.cs
+++ b/Src/RandomizerTMF/App.axaml.cs
@@ -50,7 +50,7 @@ namespace RandomizerTMF
 
         private bool IsValidGameDirectory(string? gameDirectory)
         {
-            return !string.IsNullOrWhiteSpace(gameDirectory) && RandomizerEngine.UpdateGameDirectory(gameDirectory) is { NadeoIniException: null, TmForeverException: null };
+            return !string.IsNullOrWhiteSpace(gameDirectory) && FilePathManager.UpdateGameDirectory(gameDirectory) is { NadeoIniException: null, TmForeverException: null };
         }
     }
 }

--- a/Src/RandomizerTMF/UpdateDetector.cs
+++ b/Src/RandomizerTMF/UpdateDetector.cs
@@ -29,7 +29,7 @@ internal static class UpdateDetector
             }
 
             var release = releases[0];
-            var version = release.TagName[1..];
+            var version = release.TagName[1..]; // stips v from vX.X.X
 
             if (string.Equals(version, Program.Version))
             {

--- a/Src/RandomizerTMF/ViewModels/AutosaveDetailsWindowViewModel.cs
+++ b/Src/RandomizerTMF/ViewModels/AutosaveDetailsWindowViewModel.cs
@@ -94,6 +94,6 @@ public class AutosaveDetailsWindowViewModel : WindowWithTopBarViewModelBase
             return;
         }
 
-        RandomizerEngine.OpenAutosaveIngame(AutosaveFilePath);
+        new TMForever(RandomizerEngine.Config, RandomizerEngine.Logger).OpenAutosave(AutosaveFilePath);
     }
 }

--- a/Src/RandomizerTMF/ViewModels/ControlModuleWindowViewModel.cs
+++ b/Src/RandomizerTMF/ViewModels/ControlModuleWindowViewModel.cs
@@ -14,7 +14,7 @@ public class ControlModuleWindowViewModel : WindowViewModelBase
 
     public IBrush PrimaryButtonBackground => RandomizerEngine.HasSessionRunning ? new SolidColorBrush(new Color(255, 127, 96, 0)) : Brushes.DarkGreen;
 
-    public bool CanSkip => RandomizerEngine.SkipTokenSource is not null;
+    public bool CanSkip => RandomizerEngine.CurrentSession?.SkipTokenSource is not null;
 
     public ControlModuleWindowViewModel()
     {
@@ -36,13 +36,13 @@ public class ControlModuleWindowViewModel : WindowViewModelBase
 
     public async Task PrimaryButtonClick()
     {
-        if (RandomizerEngine.HasSessionRunning)
+        if (RandomizerEngine.CurrentSession is not null)
         {
-            await RandomizerEngine.SkipMapAsync();
+            await RandomizerEngine.CurrentSession.SkipMapAsync();
             return;
         }
         
-        await RandomizerEngine.StartSessionAsync();
+        RandomizerEngine.StartSession();
 
         this.RaisePropertyChanged(nameof(PrimaryButtonText));
         this.RaisePropertyChanged(nameof(SecondaryButtonText));
@@ -54,7 +54,7 @@ public class ControlModuleWindowViewModel : WindowViewModelBase
 
     public void ReloadMapButtonClick()
     {
-        RandomizerEngine.ReloadMap();
+        RandomizerEngine.CurrentSession?.ReloadMap();
     }
 
     public async Task SecondaryButtonClick()

--- a/Src/RandomizerTMF/ViewModels/DashboardWindowViewModel.cs
+++ b/Src/RandomizerTMF/ViewModels/DashboardWindowViewModel.cs
@@ -31,8 +31,8 @@ public class DashboardWindowViewModel : WindowWithTopBarViewModelBase
         private set => this.RaiseAndSetIfChanged(ref sessions, value);
     }
 
-    public bool HasAutosavesScanned => RandomizerEngine.HasAutosavesScanned;
-    public int AutosaveScanCount => RandomizerEngine.AutosaveHeaders.Count;
+    public bool HasAutosavesScanned => AutosaveScanner.HasAutosavesScanned;
+    public int AutosaveScanCount => AutosaveScanner.AutosaveHeaders.Count;
 
     public DashboardWindowViewModel()
     {
@@ -64,7 +64,7 @@ public class DashboardWindowViewModel : WindowWithTopBarViewModelBase
     
     private async Task ScanSessionsAsync()
     {
-        foreach (var dir in Directory.EnumerateDirectories(RandomizerEngine.SessionsDirectoryPath))
+        foreach (var dir in Directory.EnumerateDirectories(FilePathManager.SessionsDirectoryPath))
         {
             var sessionYml = Path.Combine(dir, "Session.yml");
 
@@ -110,7 +110,7 @@ public class DashboardWindowViewModel : WindowWithTopBarViewModelBase
     {
         var cts = new CancellationTokenSource();
 
-        var anythingChanged = Task.Run(RandomizerEngine.ScanAutosaves);
+        var anythingChanged = Task.Run(AutosaveScanner.ScanAutosaves);
 
         await Task.WhenAny(anythingChanged, Task.Run(async () =>
         {
@@ -135,7 +135,7 @@ public class DashboardWindowViewModel : WindowWithTopBarViewModelBase
     {
         var cts = new CancellationTokenSource();
 
-        await Task.WhenAny(Task.Run(RandomizerEngine.ScanDetailsFromAutosaves), Task.Run(async () =>
+        await Task.WhenAny(Task.Run(AutosaveScanner.ScanDetailsFromAutosaves), Task.Run(async () =>
         {
             while (true)
             {
@@ -151,7 +151,7 @@ public class DashboardWindowViewModel : WindowWithTopBarViewModelBase
 
     private static IEnumerable<AutosaveModel> GetAutosaveModels()
     {
-        return RandomizerEngine.AutosaveDetails.Select(x => new AutosaveModel(x.Key, x.Value)).OrderBy(x => x.Autosave.MapName);
+        return AutosaveScanner.AutosaveDetails.Select(x => new AutosaveModel(x.Key, x.Value)).OrderBy(x => x.Autosave.MapName);
     }
 
     protected override void CloseClick()
@@ -259,7 +259,7 @@ public class DashboardWindowViewModel : WindowWithTopBarViewModelBase
 
         var autosaveModel = Autosaves[selectedIndex];
 
-        if (!RandomizerEngine.AutosaveHeaders.TryGetValue(autosaveModel.MapUid, out AutosaveHeader? autosave))
+        if (!AutosaveScanner.AutosaveHeaders.TryGetValue(autosaveModel.MapUid, out AutosaveHeader? autosave))
         {
             return;
         }
@@ -272,17 +272,14 @@ public class DashboardWindowViewModel : WindowWithTopBarViewModelBase
 
     public void OpenDownloadedMapsFolderClick()
     {
-        if (RandomizerEngine.DownloadedDirectoryPath is not null)
+        if (FilePathManager.DownloadedDirectoryPath is not null)
         {
-            ProcessUtils.OpenDir(RandomizerEngine.DownloadedDirectoryPath + Path.DirectorySeparatorChar);
+            ProcessUtils.OpenDir(FilePathManager.DownloadedDirectoryPath + Path.DirectorySeparatorChar);
         }
     }
 
     public void OpenSessionsFolderClick()
     {
-        if (RandomizerEngine.SessionsDirectoryPath is not null)
-        {
-            ProcessUtils.OpenDir(RandomizerEngine.SessionsDirectoryPath + Path.DirectorySeparatorChar);
-        }
+        ProcessUtils.OpenDir(FilePathManager.SessionsDirectoryPath + Path.DirectorySeparatorChar);
     }
 }

--- a/Src/RandomizerTMF/ViewModels/DashboardWindowViewModel.cs
+++ b/Src/RandomizerTMF/ViewModels/DashboardWindowViewModel.cs
@@ -79,7 +79,7 @@ public class DashboardWindowViewModel : WindowWithTopBarViewModelBase
             try
             {
                 var sessionYmlContent = await File.ReadAllTextAsync(sessionYml);
-                sessionData = RandomizerEngine.YamlDeserializer.Deserialize<SessionData>(sessionYmlContent);
+                sessionData = Yaml.Deserializer.Deserialize<SessionData>(sessionYmlContent);
                 sessionDataModel = new SessionDataModel(sessionData);
             }
             catch (Exception ex)

--- a/Src/RandomizerTMF/ViewModels/DashboardWindowViewModel.cs
+++ b/Src/RandomizerTMF/ViewModels/DashboardWindowViewModel.cs
@@ -173,7 +173,7 @@ public class DashboardWindowViewModel : WindowWithTopBarViewModelBase
     {
         try
         {
-            RandomizerEngine.ValidateRules();
+            Validator.ValidateRules(RandomizerEngine.Config.Rules);
         }
         catch (RuleValidationException ex)
         {

--- a/Src/RandomizerTMF/ViewModels/HistoryModuleWindowViewModel.cs
+++ b/Src/RandomizerTMF/ViewModels/HistoryModuleWindowViewModel.cs
@@ -30,19 +30,24 @@ public class HistoryModuleWindowViewModel : WindowViewModelBase
         this.RaisePropertyChanged(nameof(HasFinishedMaps));
     }
 
-    private IEnumerable<PlayedMapModel> EnumerateCurrentSessionMaps()
+    private static IEnumerable<PlayedMapModel> EnumerateCurrentSessionMaps()
     {
-        foreach (var map in RandomizerEngine.CurrentSessionAuthorMaps)
+        if (RandomizerEngine.CurrentSession is null)
+        {
+            yield break;
+        }
+
+        foreach (var map in RandomizerEngine.CurrentSession.AuthorMaps)
         {
             yield return new PlayedMapModel(map.Value, EResult.AuthorMedal);
         }
 
-        foreach (var map in RandomizerEngine.CurrentSessionGoldMaps)
+        foreach (var map in RandomizerEngine.CurrentSession.GoldMaps)
         {
             yield return new PlayedMapModel(map.Value, EResult.GoldMedal);
         }
 
-        foreach (var map in RandomizerEngine.CurrentSessionSkippedMaps)
+        foreach (var map in RandomizerEngine.CurrentSession.SkippedMaps)
         {
             yield return new PlayedMapModel(map.Value, EResult.Skipped);
         }

--- a/Src/RandomizerTMF/ViewModels/MainWindowViewModel.cs
+++ b/Src/RandomizerTMF/ViewModels/MainWindowViewModel.cs
@@ -70,7 +70,7 @@ public class MainWindowViewModel : WindowWithTopBarViewModelBase
         if (!string.IsNullOrWhiteSpace(RandomizerEngine.Config.GameDirectory))
         {
             GameDirectory = RandomizerEngine.Config.GameDirectory;
-            NadeoIni = RandomizerEngine.UpdateGameDirectory(RandomizerEngine.Config.GameDirectory);
+            NadeoIni = FilePathManager.UpdateGameDirectory(RandomizerEngine.Config.GameDirectory);
             UserDirectory = FilePathManager.UserDataDirectoryPath;
         }
     }
@@ -97,7 +97,7 @@ public class MainWindowViewModel : WindowWithTopBarViewModelBase
 
         GameDirectory = dir;
 
-        NadeoIni = RandomizerEngine.UpdateGameDirectory(dir);
+        NadeoIni = FilePathManager.UpdateGameDirectory(dir);
 
         UserDirectory = NadeoIni.NadeoIniException is null ? FilePathManager.UserDataDirectoryPath : null;
     }

--- a/Src/RandomizerTMF/ViewModels/MainWindowViewModel.cs
+++ b/Src/RandomizerTMF/ViewModels/MainWindowViewModel.cs
@@ -104,7 +104,7 @@ public class MainWindowViewModel : WindowWithTopBarViewModelBase
 
     public void SaveAndProceedClick()
     {
-        RandomizerEngine.SaveConfig();
+        RandomizerEngine.Config.Save();
 
         SwitchWindowTo<DashboardWindow, DashboardWindowViewModel>();
     }

--- a/Src/RandomizerTMF/ViewModels/MainWindowViewModel.cs
+++ b/Src/RandomizerTMF/ViewModels/MainWindowViewModel.cs
@@ -71,7 +71,7 @@ public class MainWindowViewModel : WindowWithTopBarViewModelBase
         {
             GameDirectory = RandomizerEngine.Config.GameDirectory;
             NadeoIni = RandomizerEngine.UpdateGameDirectory(RandomizerEngine.Config.GameDirectory);
-            UserDirectory = RandomizerEngine.UserDataDirectoryPath;
+            UserDirectory = FilePathManager.UserDataDirectoryPath;
         }
     }
 
@@ -99,7 +99,7 @@ public class MainWindowViewModel : WindowWithTopBarViewModelBase
 
         NadeoIni = RandomizerEngine.UpdateGameDirectory(dir);
 
-        UserDirectory = NadeoIni.NadeoIniException is null ? RandomizerEngine.UserDataDirectoryPath : null;
+        UserDirectory = NadeoIni.NadeoIniException is null ? FilePathManager.UserDataDirectoryPath : null;
     }
 
     public void SaveAndProceedClick()

--- a/Src/RandomizerTMF/ViewModels/ProgressModuleWindowViewModel.cs
+++ b/Src/RandomizerTMF/ViewModels/ProgressModuleWindowViewModel.cs
@@ -6,9 +6,9 @@ namespace RandomizerTMF.ViewModels;
 
 public class ProgressModuleWindowViewModel : WindowViewModelBase
 {
-    public int AuthorMedalCount => RandomizerEngine.CurrentSessionAuthorMaps.Count;
-    public int GoldMedalCount => RandomizerEngine.CurrentSessionGoldMaps.Count;
-    public int SkipCount => RandomizerEngine.CurrentSessionSkippedMaps.Count;
+    public int AuthorMedalCount => RandomizerEngine.CurrentSession?.AuthorMaps.Count ?? 0;
+    public int GoldMedalCount => RandomizerEngine.CurrentSession?.GoldMaps.Count ?? 0;
+    public int SkipCount => RandomizerEngine.CurrentSession?.SkippedMaps.Count ?? 0;
     public IBrush SkipColor => SkipCount == 0 ? Brushes.LightGreen : Brushes.Orange;
 
     public ProgressModuleWindowViewModel()

--- a/Src/RandomizerTMF/ViewModels/RequestRulesControlViewModel.cs
+++ b/Src/RandomizerTMF/ViewModels/RequestRulesControlViewModel.cs
@@ -16,7 +16,7 @@ public class RequestRulesControlViewModel : WindowViewModelBase
             
             this.RaisePropertyChanged(nameof(IsSiteTMNFChecked));
 
-            RandomizerEngine.SaveConfig();
+            RandomizerEngine.Config.Save();
         }
     }
     
@@ -30,7 +30,7 @@ public class RequestRulesControlViewModel : WindowViewModelBase
 
             this.RaisePropertyChanged(nameof(IsSiteTMUFChecked));
 
-            RandomizerEngine.SaveConfig();
+            RandomizerEngine.Config.Save();
         }
     }
 
@@ -44,7 +44,7 @@ public class RequestRulesControlViewModel : WindowViewModelBase
 
             this.RaisePropertyChanged(nameof(IsSiteNationsChecked));
 
-            RandomizerEngine.SaveConfig();
+            RandomizerEngine.Config.Save();
         }
     }
 
@@ -58,7 +58,7 @@ public class RequestRulesControlViewModel : WindowViewModelBase
 
             this.RaisePropertyChanged(nameof(IsSiteSunriseChecked));
 
-            RandomizerEngine.SaveConfig();
+            RandomizerEngine.Config.Save();
         }
     }
 
@@ -72,7 +72,7 @@ public class RequestRulesControlViewModel : WindowViewModelBase
 
             this.RaisePropertyChanged(nameof(IsSiteOriginalChecked));
 
-            RandomizerEngine.SaveConfig();
+            RandomizerEngine.Config.Save();
         }
     }
 
@@ -89,7 +89,7 @@ public class RequestRulesControlViewModel : WindowViewModelBase
             this.RaisePropertyChanged(nameof(IsPrimaryTypeStuntsChecked));
             this.RaisePropertyChanged(nameof(IsPrimaryTypePuzzleChecked));
 
-            RandomizerEngine.SaveConfig();
+            RandomizerEngine.Config.Save();
         }
     }
 
@@ -106,7 +106,7 @@ public class RequestRulesControlViewModel : WindowViewModelBase
             this.RaisePropertyChanged(nameof(IsPrimaryTypeStuntsChecked));
             this.RaisePropertyChanged(nameof(IsPrimaryTypePuzzleChecked));
 
-            RandomizerEngine.SaveConfig();
+            RandomizerEngine.Config.Save();
         }
     }
 
@@ -123,7 +123,7 @@ public class RequestRulesControlViewModel : WindowViewModelBase
             this.RaisePropertyChanged(nameof(IsPrimaryTypeStuntsChecked));
             this.RaisePropertyChanged(nameof(IsPrimaryTypePuzzleChecked));
 
-            RandomizerEngine.SaveConfig();
+            RandomizerEngine.Config.Save();
         }
     }
 
@@ -140,7 +140,7 @@ public class RequestRulesControlViewModel : WindowViewModelBase
             this.RaisePropertyChanged(nameof(IsPrimaryTypeStuntsChecked));
             this.RaisePropertyChanged(nameof(IsPrimaryTypePuzzleChecked));
 
-            RandomizerEngine.SaveConfig();
+            RandomizerEngine.Config.Save();
         }
     }
 
@@ -161,7 +161,7 @@ public class RequestRulesControlViewModel : WindowViewModelBase
 
             this.RaisePropertyChanged(nameof(IsEnvironmentSnowChecked));
 
-            RandomizerEngine.SaveConfig();
+            RandomizerEngine.Config.Save();
         }
     }
 
@@ -182,7 +182,7 @@ public class RequestRulesControlViewModel : WindowViewModelBase
 
             this.RaisePropertyChanged(nameof(IsEnvironmentDesertChecked));
 
-            RandomizerEngine.SaveConfig();
+            RandomizerEngine.Config.Save();
         }
     }
 
@@ -203,7 +203,7 @@ public class RequestRulesControlViewModel : WindowViewModelBase
 
             this.RaisePropertyChanged(nameof(IsEnvironmentRallyChecked));
 
-            RandomizerEngine.SaveConfig();
+            RandomizerEngine.Config.Save();
         }
     }
 
@@ -224,7 +224,7 @@ public class RequestRulesControlViewModel : WindowViewModelBase
 
             this.RaisePropertyChanged(nameof(IsEnvironmentIslandChecked));
 
-            RandomizerEngine.SaveConfig();
+            RandomizerEngine.Config.Save();
         }
     }
 
@@ -245,7 +245,7 @@ public class RequestRulesControlViewModel : WindowViewModelBase
 
             this.RaisePropertyChanged(nameof(IsEnvironmentCoastChecked));
 
-            RandomizerEngine.SaveConfig();
+            RandomizerEngine.Config.Save();
         }
     }
 
@@ -266,7 +266,7 @@ public class RequestRulesControlViewModel : WindowViewModelBase
 
             this.RaisePropertyChanged(nameof(IsEnvironmentBayChecked));
 
-            RandomizerEngine.SaveConfig();
+            RandomizerEngine.Config.Save();
         }
     }
 
@@ -287,7 +287,7 @@ public class RequestRulesControlViewModel : WindowViewModelBase
 
             this.RaisePropertyChanged(nameof(IsEnvironmentStadiumChecked));
 
-            RandomizerEngine.SaveConfig();
+            RandomizerEngine.Config.Save();
         }
     }
 
@@ -308,7 +308,7 @@ public class RequestRulesControlViewModel : WindowViewModelBase
 
             this.RaisePropertyChanged(nameof(IsVehicleSnowChecked));
 
-            RandomizerEngine.SaveConfig();
+            RandomizerEngine.Config.Save();
         }
     }
 
@@ -329,7 +329,7 @@ public class RequestRulesControlViewModel : WindowViewModelBase
 
             this.RaisePropertyChanged(nameof(IsVehicleDesertChecked));
 
-            RandomizerEngine.SaveConfig();
+            RandomizerEngine.Config.Save();
         }
     }
 
@@ -350,7 +350,7 @@ public class RequestRulesControlViewModel : WindowViewModelBase
 
             this.RaisePropertyChanged(nameof(IsVehicleRallyChecked));
 
-            RandomizerEngine.SaveConfig();
+            RandomizerEngine.Config.Save();
         }
     }
 
@@ -371,7 +371,7 @@ public class RequestRulesControlViewModel : WindowViewModelBase
 
             this.RaisePropertyChanged(nameof(IsVehicleIslandChecked));
 
-            RandomizerEngine.SaveConfig();
+            RandomizerEngine.Config.Save();
         }
     }
 
@@ -392,7 +392,7 @@ public class RequestRulesControlViewModel : WindowViewModelBase
 
             this.RaisePropertyChanged(nameof(IsVehicleCoastChecked));
 
-            RandomizerEngine.SaveConfig();
+            RandomizerEngine.Config.Save();
         }
     }
 
@@ -413,7 +413,7 @@ public class RequestRulesControlViewModel : WindowViewModelBase
 
             this.RaisePropertyChanged(nameof(IsVehicleBayChecked));
 
-            RandomizerEngine.SaveConfig();
+            RandomizerEngine.Config.Save();
         }
     }
 
@@ -434,7 +434,7 @@ public class RequestRulesControlViewModel : WindowViewModelBase
 
             this.RaisePropertyChanged(nameof(IsVehicleStadiumChecked));
 
-            RandomizerEngine.SaveConfig();
+            RandomizerEngine.Config.Save();
         }
     }
 
@@ -455,7 +455,7 @@ public class RequestRulesControlViewModel : WindowViewModelBase
 
             this.RaisePropertyChanged(nameof(IsDifficultyBeginnerChecked));
 
-            RandomizerEngine.SaveConfig();
+            RandomizerEngine.Config.Save();
         }
     }
 
@@ -476,7 +476,7 @@ public class RequestRulesControlViewModel : WindowViewModelBase
 
             this.RaisePropertyChanged(nameof(IsDifficultyIntermediateChecked));
 
-            RandomizerEngine.SaveConfig();
+            RandomizerEngine.Config.Save();
         }
     }
 
@@ -497,7 +497,7 @@ public class RequestRulesControlViewModel : WindowViewModelBase
 
             this.RaisePropertyChanged(nameof(IsDifficultyExpertChecked));
 
-            RandomizerEngine.SaveConfig();
+            RandomizerEngine.Config.Save();
         }
     }
 
@@ -518,7 +518,7 @@ public class RequestRulesControlViewModel : WindowViewModelBase
 
             this.RaisePropertyChanged(nameof(IsDifficultyLunaticChecked));
 
-            RandomizerEngine.SaveConfig();
+            RandomizerEngine.Config.Save();
         }
     }
 
@@ -539,7 +539,7 @@ public class RequestRulesControlViewModel : WindowViewModelBase
 
             this.RaisePropertyChanged(nameof(IsRouteSingleChecked));
 
-            RandomizerEngine.SaveConfig();
+            RandomizerEngine.Config.Save();
         }
     }
 
@@ -560,7 +560,7 @@ public class RequestRulesControlViewModel : WindowViewModelBase
 
             this.RaisePropertyChanged(nameof(IsRouteMultiChecked));
 
-            RandomizerEngine.SaveConfig();
+            RandomizerEngine.Config.Save();
         }
     }
 
@@ -581,7 +581,7 @@ public class RequestRulesControlViewModel : WindowViewModelBase
 
             this.RaisePropertyChanged(nameof(IsRouteSymmetricChecked));
 
-            RandomizerEngine.SaveConfig();
+            RandomizerEngine.Config.Save();
         }
     }
 
@@ -602,7 +602,7 @@ public class RequestRulesControlViewModel : WindowViewModelBase
 
             this.RaisePropertyChanged(nameof(IsMoodSunriseChecked));
 
-            RandomizerEngine.SaveConfig();
+            RandomizerEngine.Config.Save();
         }
     }
 
@@ -623,7 +623,7 @@ public class RequestRulesControlViewModel : WindowViewModelBase
 
             this.RaisePropertyChanged(nameof(IsMoodDayChecked));
 
-            RandomizerEngine.SaveConfig();
+            RandomizerEngine.Config.Save();
         }
     }
 
@@ -644,7 +644,7 @@ public class RequestRulesControlViewModel : WindowViewModelBase
 
             this.RaisePropertyChanged(nameof(IsMoodSunsetChecked));
 
-            RandomizerEngine.SaveConfig();
+            RandomizerEngine.Config.Save();
         }
     }
 
@@ -665,7 +665,7 @@ public class RequestRulesControlViewModel : WindowViewModelBase
 
             this.RaisePropertyChanged(nameof(IsMoodNightChecked));
 
-            RandomizerEngine.SaveConfig();
+            RandomizerEngine.Config.Save();
         }
     }
 
@@ -678,7 +678,7 @@ public class RequestRulesControlViewModel : WindowViewModelBase
 
             this.RaisePropertyChanged(nameof(MapName));
 
-            RandomizerEngine.SaveConfig();
+            RandomizerEngine.Config.Save();
         }
     }
 
@@ -691,7 +691,7 @@ public class RequestRulesControlViewModel : WindowViewModelBase
 
             this.RaisePropertyChanged(nameof(MapAuthor));
 
-            RandomizerEngine.SaveConfig();
+            RandomizerEngine.Config.Save();
         }
     }
 
@@ -707,7 +707,7 @@ public class RequestRulesControlViewModel : WindowViewModelBase
 
             this.RaisePropertyChanged(nameof(TagIndex));
 
-            RandomizerEngine.SaveConfig();
+            RandomizerEngine.Config.Save();
         }
     }
 
@@ -723,7 +723,7 @@ public class RequestRulesControlViewModel : WindowViewModelBase
 
             this.RaisePropertyChanged(nameof(LbTypeIndex));
 
-            RandomizerEngine.SaveConfig();
+            RandomizerEngine.Config.Save();
         }
     }
 
@@ -738,7 +738,7 @@ public class RequestRulesControlViewModel : WindowViewModelBase
 
             this.RaisePropertyChanged(nameof(TimeLimitHour));
 
-            RandomizerEngine.SaveConfig();
+            RandomizerEngine.Config.Save();
         }
     }
 
@@ -753,7 +753,7 @@ public class RequestRulesControlViewModel : WindowViewModelBase
 
             this.RaisePropertyChanged(nameof(TimeLimitMinute));
 
-            RandomizerEngine.SaveConfig();
+            RandomizerEngine.Config.Save();
         }
     }
 
@@ -768,7 +768,7 @@ public class RequestRulesControlViewModel : WindowViewModelBase
 
             this.RaisePropertyChanged(nameof(TimeLimitSecond));
 
-            RandomizerEngine.SaveConfig();
+            RandomizerEngine.Config.Save();
         }
     }
 
@@ -783,7 +783,7 @@ public class RequestRulesControlViewModel : WindowViewModelBase
 
             this.RaisePropertyChanged(nameof(MinATMinute));
 
-            RandomizerEngine.SaveConfig();
+            RandomizerEngine.Config.Save();
         }
     }
 
@@ -799,7 +799,7 @@ public class RequestRulesControlViewModel : WindowViewModelBase
 
             this.RaisePropertyChanged(nameof(MinATSecond));
 
-            RandomizerEngine.SaveConfig();
+            RandomizerEngine.Config.Save();
         }
     }
 
@@ -815,7 +815,7 @@ public class RequestRulesControlViewModel : WindowViewModelBase
 
             this.RaisePropertyChanged(nameof(MinATMillisecond));
 
-            RandomizerEngine.SaveConfig();
+            RandomizerEngine.Config.Save();
         }
     }
 
@@ -831,7 +831,7 @@ public class RequestRulesControlViewModel : WindowViewModelBase
             this.RaisePropertyChanged(nameof(MinATSecond));
             this.RaisePropertyChanged(nameof(MinATMillisecond));
 
-            RandomizerEngine.SaveConfig();
+            RandomizerEngine.Config.Save();
         }
     }
 
@@ -846,7 +846,7 @@ public class RequestRulesControlViewModel : WindowViewModelBase
 
             this.RaisePropertyChanged(nameof(MaxATMinute));
 
-            RandomizerEngine.SaveConfig();
+            RandomizerEngine.Config.Save();
         }
     }
 
@@ -862,7 +862,7 @@ public class RequestRulesControlViewModel : WindowViewModelBase
 
             this.RaisePropertyChanged(nameof(MaxATSecond));
 
-            RandomizerEngine.SaveConfig();
+            RandomizerEngine.Config.Save();
         }
     }
 
@@ -878,7 +878,7 @@ public class RequestRulesControlViewModel : WindowViewModelBase
 
             this.RaisePropertyChanged(nameof(MaxATMillisecond));
 
-            RandomizerEngine.SaveConfig();
+            RandomizerEngine.Config.Save();
         }
     }
 
@@ -894,7 +894,7 @@ public class RequestRulesControlViewModel : WindowViewModelBase
             this.RaisePropertyChanged(nameof(MaxATSecond));
             this.RaisePropertyChanged(nameof(MaxATMillisecond));
 
-            RandomizerEngine.SaveConfig();
+            RandomizerEngine.Config.Save();
         }
     }
 
@@ -907,7 +907,7 @@ public class RequestRulesControlViewModel : WindowViewModelBase
 
             this.RaisePropertyChanged(nameof(UploadedAfter));
 
-            RandomizerEngine.SaveConfig();
+            RandomizerEngine.Config.Save();
         }
     }
 
@@ -922,7 +922,7 @@ public class RequestRulesControlViewModel : WindowViewModelBase
 
             this.RaisePropertyChanged(nameof(UploadedBefore));
 
-            RandomizerEngine.SaveConfig();
+            RandomizerEngine.Config.Save();
         }
     }
 
@@ -935,7 +935,7 @@ public class RequestRulesControlViewModel : WindowViewModelBase
 
             this.RaisePropertyChanged(nameof(EqualEnvDistribution));
 
-            RandomizerEngine.SaveConfig();
+            RandomizerEngine.Config.Save();
         }
     }
     
@@ -948,7 +948,7 @@ public class RequestRulesControlViewModel : WindowViewModelBase
 
             this.RaisePropertyChanged(nameof(EqualVehicleDistribution));
 
-            RandomizerEngine.SaveConfig();
+            RandomizerEngine.Config.Save();
         }
     }
 

--- a/Src/RandomizerTMF/ViewModels/SessionDataViewModel.cs
+++ b/Src/RandomizerTMF/ViewModels/SessionDataViewModel.cs
@@ -175,22 +175,16 @@ public partial class SessionDataViewModel : WindowWithTopBarViewModelBase
 
     public void OpenSessionFolderClick()
     {
-        if (RandomizerEngine.SessionsDirectoryPath is not null)
-        {
-            ProcessUtils.OpenDir(Path.Combine(RandomizerEngine.SessionsDirectoryPath, Model.Data.StartedAtText) + Path.DirectorySeparatorChar);
-        }
+        ProcessUtils.OpenDir(Path.Combine(FilePathManager.SessionsDirectoryPath, Model.Data.StartedAtText) + Path.DirectorySeparatorChar);
     }
 
     public void OpenReplaysFolderClick()
     {
-        if (RandomizerEngine.SessionsDirectoryPath is not null)
-        {
-            var replaysDir = Path.Combine(RandomizerEngine.SessionsDirectoryPath, Model.Data.StartedAtText, Constants.Replays);
+        var replaysDir = Path.Combine(FilePathManager.SessionsDirectoryPath, Model.Data.StartedAtText, Constants.Replays);
 
-            if (Directory.Exists(replaysDir))
-            {
-                ProcessUtils.OpenDir(replaysDir + Path.DirectorySeparatorChar);
-            }
+        if (Directory.Exists(replaysDir))
+        {
+            ProcessUtils.OpenDir(replaysDir + Path.DirectorySeparatorChar);
         }
     }
 

--- a/Src/RandomizerTMF/ViewModels/StatusModuleWindowViewModel.cs
+++ b/Src/RandomizerTMF/ViewModels/StatusModuleWindowViewModel.cs
@@ -47,9 +47,9 @@ public class StatusModuleWindowViewModel : WindowViewModelBase
         {
             while (true)
             {
-                if (RandomizerEngine.CurrentSessionWatch is not null)
+                if (RandomizerEngine.CurrentSession?.Watch is not null)
                 {
-                    Time = RandomizerEngine.Config.Rules.TimeLimit - RandomizerEngine.CurrentSessionWatch.Elapsed;
+                    Time = RandomizerEngine.Config.Rules.TimeLimit - RandomizerEngine.CurrentSession.Watch.Elapsed;
                     this.RaisePropertyChanged(nameof(TimeText));
                 }
 

--- a/Src/RandomizerTMF/Views/ControlModuleWindow.axaml.cs
+++ b/Src/RandomizerTMF/Views/ControlModuleWindow.axaml.cs
@@ -16,7 +16,7 @@ namespace RandomizerTMF.Views
                 RandomizerEngine.Config.Modules.Control.Width = Convert.ToInt32(Width);
                 RandomizerEngine.Config.Modules.Control.Height = Convert.ToInt32(Height);
 
-                RandomizerEngine.SaveConfig();
+                RandomizerEngine.Config.Save();
             };
 
             Deactivated += (_, _) => { Topmost = false; Topmost = true; };

--- a/Src/RandomizerTMF/Views/HistoryModuleWindow.axaml.cs
+++ b/Src/RandomizerTMF/Views/HistoryModuleWindow.axaml.cs
@@ -18,7 +18,7 @@ namespace RandomizerTMF.Views
                 RandomizerEngine.Config.Modules.History.Width = Convert.ToInt32(Width);
                 RandomizerEngine.Config.Modules.History.Height = Convert.ToInt32(Height);
 
-                RandomizerEngine.SaveConfig();
+                RandomizerEngine.Config.Save();
             };
 
             Deactivated += (_, _) => { Topmost = false; Topmost = true; };

--- a/Src/RandomizerTMF/Views/ProgressModuleWindow.axaml.cs
+++ b/Src/RandomizerTMF/Views/ProgressModuleWindow.axaml.cs
@@ -16,7 +16,7 @@ namespace RandomizerTMF.Views
                 RandomizerEngine.Config.Modules.Progress.Width = Convert.ToInt32(Width);
                 RandomizerEngine.Config.Modules.Progress.Height = Convert.ToInt32(Height);
 
-                RandomizerEngine.SaveConfig();
+                RandomizerEngine.Config.Save();
             };
 
             Deactivated += (_, _) => { Topmost = false; Topmost = true; };

--- a/Src/RandomizerTMF/Views/StatusModuleWindow.axaml.cs
+++ b/Src/RandomizerTMF/Views/StatusModuleWindow.axaml.cs
@@ -16,7 +16,7 @@ namespace RandomizerTMF.Views
                 RandomizerEngine.Config.Modules.Status.Width = Convert.ToInt32(Width);
                 RandomizerEngine.Config.Modules.Status.Height = Convert.ToInt32(Height);
 
-                RandomizerEngine.SaveConfig();
+                RandomizerEngine.Config.Save();
             };
 
             Deactivated += (_, _) => { Topmost = false; Topmost = true; };


### PR DESCRIPTION
This pull request aims to plan out and improve the situation with the [`RandomizerEngine`](https://github.com/BigBang1112/randomizer-tmf/blob/class-sep/Src/RandomizerTMF.Logic/RandomizerEngine.cs) class.

- It has way too many lines of code
- It does not follow the single-responsibility principle that well
- It has a lot of `CurrentSessionXXX` properties that should be packed under single `CurrentSession` class or similar

No DI and unit testing yet. All of the individual classes should keep the `static` design for the time being (for the "part 1").