### PR TITLE
Randomizer TMF 1.1.4

### DIFF
--- a/Src/RandomizerTMF.Logic/RandomizerRules.cs
+++ b/Src/RandomizerTMF.Logic/RandomizerRules.cs
@@ -14,17 +14,54 @@ public class RandomizerRules
         AuthorTimeMax = TimeInt32.FromMinutes(3)
     };
 
-    public void Serialize(BinaryWriter writer)
+    public Dictionary<ESite, HashSet<uint>> BannedMaps { get; init; } = [];
+
+    public void Serialize(BinaryWriter writer, int version)
     {
         writer.Write(TimeLimit.Ticks);
         writer.Write(NoUnlimiter);
         RequestRules.Serialize(writer);
+
+        if (version < 1)
+		{
+			return;
+		}
+
+        writer.Write(BannedMaps.Count);
+        foreach (var (site, ids) in BannedMaps)
+		{
+			writer.Write((int)site);
+			writer.Write(ids.Count);
+			foreach (var id in ids)
+			{
+				writer.Write(id);
+			}
+		}
     }
 
-    public void Deserialize(BinaryReader r)
+    public void Deserialize(BinaryReader r, int version)
     {
         TimeLimit = TimeSpan.FromTicks(r.ReadInt64());
         NoUnlimiter = r.ReadBoolean();
         RequestRules.Deserialize(r);
+
+        if (version < 1)
+		{
+			return;
+		}
+
+        var count = r.ReadInt32();
+        BannedMaps.Clear();
+        for (var i = 0; i < count; i++)
+		{
+			var site = (ESite)r.ReadInt32();
+            var mapCount = r.ReadInt32();
+			var ids = new HashSet<uint>(mapCount);
+			for (var j = 0; j < mapCount; j++)
+			{
+				ids.Add(r.ReadUInt32());
+			}
+			BannedMaps.Add(site, ids);
+		}
     }
 }

--- a/Src/RandomizerTMF.Logic/RandomizerTMF.Logic.csproj
+++ b/Src/RandomizerTMF.Logic/RandomizerTMF.Logic.csproj
@@ -13,7 +13,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="DiscordRichPresence" Version="1.2.1.24" />
-		<PackageReference Include="GBX.NET" Version="2.0.4" />
+		<PackageReference Include="GBX.NET" Version="2.0.5" />
 		<PackageReference Include="GBX.NET.LZO" Version="2.0.0" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
 		<PackageReference Include="System.IO.Abstractions" Version="21.0.22" />

--- a/Src/RandomizerTMF.Logic/RandomizerTMF.Logic.csproj
+++ b/Src/RandomizerTMF.Logic/RandomizerTMF.Logic.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<Version>1.1.3</Version>
+		<Version>1.1.4</Version>
 		<TargetFramework>net8.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>

--- a/Src/RandomizerTMF.Logic/RequestRules.cs
+++ b/Src/RandomizerTMF.Logic/RequestRules.cs
@@ -47,7 +47,7 @@ public class RequestRules
     public TimeInt32? AuthorTimeMin { get; set; }
     public TimeInt32? AuthorTimeMax { get; set; }
 
-    public string ToUrl(IRandomGenerator random) // Not very efficient but does the job done fast enough
+    public string ToUrl(IRandomGenerator random, out ESite site) // Not very efficient but does the job done fast enough
     {
         var b = new StringBuilder("https://");
 
@@ -56,7 +56,7 @@ public class RequestRules
             .ToArray();
 
         // If Site is Any, then it picks from sites that are valid within environments and cars
-        var site = GetRandomSite(random, matchingSites.Length == 0
+        site = GetRandomSite(random, matchingSites.Length == 0
             ? siteValues.Where(x => x is not ESite.Any
             && IsSiteValidWithEnvironments(x)
             && IsSiteValidWithVehicles(x)

--- a/Src/RandomizerTMF.Logic/Services/AutosaveScanner.cs
+++ b/Src/RandomizerTMF.Logic/Services/AutosaveScanner.cs
@@ -106,7 +106,7 @@ public class AutosaveScanner : IAutosaveScanner
 
                 using var stream = fileSystem.File.OpenRead(e.FullPath);
 
-                if (GameBox.ParseNode(stream) is not CGameCtnReplayRecord r)
+                if (Gbx.ParseNode(stream) is not CGameCtnReplayRecord r)
                 {
                     logger.LogWarning("Found file {file} that is not a replay.", e.FullPath);
                     return;

--- a/Src/RandomizerTMF.Logic/SessionData.cs
+++ b/Src/RandomizerTMF.Logic/SessionData.cs
@@ -233,7 +233,7 @@ public class SessionData
         }
 
         var version = reader.ReadByte();
-        if (version != 0)
+        if (version > 1)
         {
             throw new InvalidDataException("Invalid version.");
         }

--- a/Src/RandomizerTMF.Logic/SessionData.cs
+++ b/Src/RandomizerTMF.Logic/SessionData.cs
@@ -193,8 +193,10 @@ public class SessionData
 
     public void Serialize(BinaryWriter writer)
     {
+        const int version = 1;
+
         writer.Write("RandTMF");
-        writer.Write((byte)0); // version
+        writer.Write((byte)version); // version
         
         using var aes = Aes.Create();
         aes.GenerateKey();
@@ -213,7 +215,7 @@ public class SessionData
         w.Write(StartedAt.Ticks);
         w.Write((short)StartedAt.TotalOffsetMinutes);
 
-        Rules.Serialize(w);
+        Rules.Serialize(w, version);
 
         w.Write(Maps.Count);
         foreach (var map in Maps)
@@ -255,7 +257,7 @@ public class SessionData
         DirectoryPath = Path.Combine(FilePathManager.SessionsDirectoryPath, StartedAtText);
 
         Rules = new();
-        Rules.Deserialize(r);
+        Rules.Deserialize(r, version);
 
         Maps.Clear();
         var mapsCount = r.ReadInt32();

--- a/Src/RandomizerTMF/RandomizerTMF.csproj
+++ b/Src/RandomizerTMF/RandomizerTMF.csproj
@@ -5,7 +5,7 @@
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<Version>1.1.3</Version>
+		<Version>1.1.4</Version>
 		<PublishSingleFile>true</PublishSingleFile>
 		<EnableCompressionInSingleFile>true</EnableCompressionInSingleFile>
 	</PropertyGroup>

--- a/Src/RandomizerTMF/Views/RequestRulesControl.axaml
+++ b/Src/RandomizerTMF/Views/RequestRulesControl.axaml
@@ -190,7 +190,7 @@
 				<TextBlock Text=":" VerticalAlignment="Center" FontSize="16" FontWeight="Bold"/>
 				<NumericUpDown IsEnabled="{Binding MinATEnabled}" Value="{Binding MinATSecond}" FormatString="00" Maximum="59" Minimum="0" Width="38" MinWidth="38" VerticalContentAlignment="Center" ShowButtonSpinner="False" ToolTip.Tip="Seconds"/>
 				<TextBlock Text="." VerticalAlignment="Center" FontSize="16" FontWeight="Bold"/>
-				<NumericUpDown IsEnabled="{Binding MinATEnabled}" Value="{Binding MinATMillisecond}" FormatString="00" Maximum="59" Minimum="0" Width="38" MinWidth="38" VerticalContentAlignment="Center" ShowButtonSpinner="False" ToolTip.Tip="Hundredths"/>
+				<NumericUpDown IsEnabled="{Binding MinATEnabled}" Value="{Binding MinATMillisecond}" FormatString="00" Maximum="99" Minimum="0" Width="38" MinWidth="38" VerticalContentAlignment="Center" ShowButtonSpinner="False" ToolTip.Tip="Hundredths"/>
 				<CheckBox IsChecked="{Binding MinATEnabled}" ToolTip.Tip="Enable/disable minimal author time filter."/>
 			</StackPanel>
 
@@ -201,7 +201,7 @@
 				<TextBlock Text=":" VerticalAlignment="Center" FontSize="16" FontWeight="Bold"/>
 				<NumericUpDown IsEnabled="{Binding MaxATEnabled}" Value="{Binding MaxATSecond}" FormatString="00" Maximum="59" Minimum="0" Width="38" MinWidth="38" VerticalContentAlignment="Center" ShowButtonSpinner="False" ToolTip.Tip="Seconds"/>
 				<TextBlock Text="." VerticalAlignment="Center" FontSize="16" FontWeight="Bold"/>
-				<NumericUpDown IsEnabled="{Binding MaxATEnabled}" Value="{Binding MaxATMillisecond}" FormatString="00" Maximum="59" Minimum="0" Width="38" MinWidth="38" VerticalContentAlignment="Center" ShowButtonSpinner="False" ToolTip.Tip="Hundredths"/>
+				<NumericUpDown IsEnabled="{Binding MaxATEnabled}" Value="{Binding MaxATMillisecond}" FormatString="00" Maximum="99" Minimum="0" Width="38" MinWidth="38" VerticalContentAlignment="Center" ShowButtonSpinner="False" ToolTip.Tip="Hundredths"/>
 				<CheckBox IsChecked="{Binding MaxATEnabled}" ToolTip.Tip="Enable/disable maximal author time filter."/>
 			</StackPanel>
 

--- a/Tests/RandomizerTMF.Logic.Tests/Integration/SessionDataTests.cs
+++ b/Tests/RandomizerTMF.Logic.Tests/Integration/SessionDataTests.cs
@@ -19,8 +19,10 @@ public class SessionDataTests
         var serialized = new SessionData();
         serialized.Rules.RequestRules.Environment = [EEnvironment.Desert];
         serialized.Rules.RequestRules.UploadedAfter = DateOnly.MaxValue;
+        serialized.Rules.BannedMaps.Add(ESite.TMNF, [123, 1456]);
+		serialized.Rules.BannedMaps.Add(ESite.Nations, [1234, 14586]);
 
-        using var ms = new MemoryStream();
+		using var ms = new MemoryStream();
         using var w = new BinaryWriter(ms);
         serialized.Serialize(w);
 

--- a/Tests/RandomizerTMF.Logic.Tests/RandomizerTMF.Logic.Tests.csproj
+++ b/Tests/RandomizerTMF.Logic.Tests/RandomizerTMF.Logic.Tests.csproj
@@ -14,8 +14,8 @@
 		<PackageReference Include="Moq" Version="4.20.70" />
 		<PackageReference Include="RichardSzalay.MockHttp" Version="7.0.0" />
 		<PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="21.0.22" />
-		<PackageReference Include="xunit" Version="2.8.1" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.8.1">
+		<PackageReference Include="xunit" Version="2.9.0" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>

--- a/Tests/RandomizerTMF.Logic.Tests/Unit/Services/MapDownloaderTests.cs
+++ b/Tests/RandomizerTMF.Logic.Tests/Unit/Services/MapDownloaderTests.cs
@@ -328,7 +328,7 @@ public class MapDownloaderTests
     }
 
     [Fact]
-    public async Task FetchRandomTrackAsync_MapNotFound_Throws()
+    public async Task PrepareNewMapAsync_MapNotFound_Throws()
     {
         // Arrange
         var events = Mock.Of<IRandomizerEvents>();
@@ -341,47 +341,19 @@ public class MapDownloaderTests
         var delay = Mock.Of<IDelayService>();
         var logger = Mock.Of<ILogger>();
         var gbxService = Mock.Of<IGbxService>();
+		var game = Mock.Of<ITMForever>();
 
-        var mockHandler = new MockHttpMessageHandler();
+		var mockHandler = new MockHttpMessageHandler();
         mockHandler.When("https://tmnf.exchange/trackrandom?primarytype=0&authortimemax=180000").Respond(HttpStatusCode.NotFound);
         var http = new HttpClient(mockHandler);
 
         var mapDownloader = new MapDownloader(events, config, filePathManager, discord, validator, http, random, delay, fileSystem, gbxService, logger);
+		var session = new Session(events, mapDownloader, validator, config, game, logger, fileSystem);
 
-        var cts = new CancellationTokenSource();
+		var cts = new CancellationTokenSource();
 
         // Act & Assert
-        await Assert.ThrowsAsync<InvalidSessionException>(async () => await mapDownloader.FetchRandomTrackAsync(cts.Token));
-    }
-
-    [Fact]
-    public async Task FetchRandomTrackAsync_Success_ReturnsResponse()
-    {
-        // Arrange
-        var events = Mock.Of<IRandomizerEvents>();
-        var config = new RandomizerConfig();
-        var fileSystem = new MockFileSystem();
-        var filePathManager = new FilePathManager(config, fileSystem);
-        var discord = Mock.Of<IDiscordRichPresence>();
-        var validator = Mock.Of<IValidator>();
-        var random = Mock.Of<IRandomGenerator>();
-        var delay = Mock.Of<IDelayService>();
-        var logger = Mock.Of<ILogger>();
-        var gbxService = Mock.Of<IGbxService>();
-
-        var mockHandler = new MockHttpMessageHandler();
-        mockHandler.When("https://tmnf.exchange/trackrandom?primarytype=0&authortimemax=180000").Respond(HttpStatusCode.OK);
-        var http = new HttpClient(mockHandler);
-
-        var mapDownloader = new MapDownloader(events, config, filePathManager, discord, validator, http, random, delay, fileSystem, gbxService, logger);
-
-        var cts = new CancellationTokenSource();
-
-        // Act
-        var response = await mapDownloader.FetchRandomTrackAsync(cts.Token);
-
-        // Assert
-        Assert.Equal(expected: HttpStatusCode.OK, actual: response.StatusCode);
+        await Assert.ThrowsAsync<InvalidSessionException>(async () => await mapDownloader.PrepareNewMapAsync(session, cts.Token));
     }
 
     [Fact]


### PR DESCRIPTION
- Added `BannedMaps` to `Config.yml` in the `Rules` section
  - Specify TMX type and a list of track IDs to not show when randomizing
  - This info is included in the session file, and is therefore **not valid for regular RMC records**
  - See below how to specify the track IDs correctly
- Fixed Min/Max AT hundredths to be limited to 99 instead of 59 (thx fabi for report)
- Finished the secured sessions transition completely
- Updated dependencies

How to specify banned track IDs: **(spacing has to be followed like shown here!)**
```yml
    AuthorTimeMax: 3:00.00 # here just for context
  BannedMaps: # remove the {} that's there by default
    TMNF:
    - 1234
    - 5678
    TMUF:
    - 91011
    - 121314
    - 151617
    Nations:
    - ... etc
```
Possible TMX type values: `TMNF`, `TMUF`, `Nations`, `Sunrise`, `Original`