### PR TITLE
RandomizerTMF 1.1.5

### DIFF
--- a/Src/RandomizerTMF.Logic/Exceptions/ConfigCorruptedException.cs
+++ b/Src/RandomizerTMF.Logic/Exceptions/ConfigCorruptedException.cs
@@ -1,0 +1,9 @@
+﻿namespace RandomizerTMF.Logic.Exceptions;
+
+[Serializable]
+public class ConfigCorruptedException : Exception
+{
+    public ConfigCorruptedException() { }
+    public ConfigCorruptedException(string message) : base(message) { }
+    public ConfigCorruptedException(string message, Exception inner) : base(message, inner) { }
+}

--- a/Src/RandomizerTMF.Logic/RandomizerRules.cs
+++ b/Src/RandomizerTMF.Logic/RandomizerRules.cs
@@ -15,6 +15,7 @@ public class RandomizerRules
     };
 
     public Dictionary<ESite, HashSet<uint>> BannedMaps { get; init; } = [];
+    public bool AvoidSkippedMaps { get; set; }
 
     public void Serialize(BinaryWriter writer, int version)
     {
@@ -37,6 +38,13 @@ public class RandomizerRules
 				writer.Write(id);
 			}
 		}
+
+        if (version < 2)
+        {
+            return;
+        }
+
+        writer.Write(AvoidSkippedMaps);
     }
 
     public void Deserialize(BinaryReader r, int version)
@@ -63,5 +71,12 @@ public class RandomizerRules
 			}
 			BannedMaps.Add(site, ids);
 		}
+
+        if (version < 2)
+        {
+            return;
+        }
+
+        AvoidSkippedMaps = r.ReadBoolean();
     }
 }

--- a/Src/RandomizerTMF.Logic/RandomizerRules.cs
+++ b/Src/RandomizerTMF.Logic/RandomizerRules.cs
@@ -20,7 +20,7 @@ public class RandomizerRules
     {
         writer.Write(TimeLimit.Ticks);
         writer.Write(NoUnlimiter);
-        RequestRules.Serialize(writer);
+        RequestRules.Serialize(writer, version);
 
         if (version < 1)
 		{
@@ -43,7 +43,7 @@ public class RandomizerRules
     {
         TimeLimit = TimeSpan.FromTicks(r.ReadInt64());
         NoUnlimiter = r.ReadBoolean();
-        RequestRules.Deserialize(r);
+        RequestRules.Deserialize(r, version);
 
         if (version < 1)
 		{

--- a/Src/RandomizerTMF.Logic/RandomizerTMF.Logic.csproj
+++ b/Src/RandomizerTMF.Logic/RandomizerTMF.Logic.csproj
@@ -13,10 +13,10 @@
 
 	<ItemGroup>
 		<PackageReference Include="DiscordRichPresence" Version="1.2.1.24" />
-		<PackageReference Include="GBX.NET" Version="2.0.5" />
-		<PackageReference Include="GBX.NET.LZO" Version="2.0.0" />
+		<PackageReference Include="GBX.NET" Version="2.0.6" />
+		<PackageReference Include="GBX.NET.LZO" Version="2.1.0" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
-		<PackageReference Include="System.IO.Abstractions" Version="21.0.22" />
+		<PackageReference Include="System.IO.Abstractions" Version="21.0.29" />
 		<PackageReference Include="YamlDotNet" Version="15.3.0" />
 	</ItemGroup>
 

--- a/Src/RandomizerTMF.Logic/RandomizerTMF.Logic.csproj
+++ b/Src/RandomizerTMF.Logic/RandomizerTMF.Logic.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<Version>1.1.4</Version>
+		<Version>1.1.5</Version>
 		<TargetFramework>net8.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>

--- a/Src/RandomizerTMF.Logic/RequestRules.cs
+++ b/Src/RandomizerTMF.Logic/RequestRules.cs
@@ -42,6 +42,7 @@ public class RequestRules
     public bool? InLatestAuthor { get; set; }
     public bool? InLatestAwardedAuthor { get; set; }
     public bool? InScreenshot { get; set; }
+    public bool? InUnlimiter { get; set; }
     public DateOnly? UploadedBefore { get; set; }
     public DateOnly? UploadedAfter { get; set; }
     public TimeInt32? AuthorTimeMin { get; set; }
@@ -268,7 +269,7 @@ public class RequestRules
         }
     }
 
-    public void Serialize(BinaryWriter writer)
+    public void Serialize(BinaryWriter writer, int version)
     {
         writer.Write((int)Site);
         writer.Write(EqualEnvironmentDistribution);
@@ -330,13 +331,19 @@ public class RequestRules
         writer.Write(InLatestAuthor.HasValue ? Convert.ToByte(InLatestAuthor.Value) : (byte)255);
         writer.Write(InLatestAwardedAuthor.HasValue ? Convert.ToByte(InLatestAwardedAuthor.Value) : (byte)255);
         writer.Write(InScreenshot.HasValue ? Convert.ToByte(InScreenshot.Value) : (byte)255);
+
+        if (version >= 2)
+        {
+            writer.Write(InUnlimiter.HasValue ? Convert.ToByte(InUnlimiter.Value) : (byte)255);
+        }
+
         writer.Write(UploadedBefore?.ToString("yyyy-MM-dd") ?? string.Empty);
         writer.Write(UploadedAfter?.ToString("yyyy-MM-dd") ?? string.Empty);
         writer.Write(AuthorTimeMin?.TotalMilliseconds ?? 0);
         writer.Write(AuthorTimeMax?.TotalMilliseconds ?? 0);
     }
 
-    public void Deserialize(BinaryReader r)
+    public void Deserialize(BinaryReader r, int version)
     {
         Site = (ESite)r.ReadInt32();
         EqualEnvironmentDistribution = r.ReadBoolean();
@@ -420,6 +427,13 @@ public class RequestRules
         InLatestAwardedAuthor = inLatestAwardedAuthor == 255 ? null : Convert.ToBoolean(inLatestAwardedAuthor);
         var inScreenshot = r.ReadByte();
         InScreenshot = inScreenshot == 255 ? null : Convert.ToBoolean(inScreenshot);
+
+        if (version >= 2)
+        {
+            var inUnlimiter = r.ReadByte();
+            InUnlimiter = inUnlimiter == 255 ? null : Convert.ToBoolean(inUnlimiter);
+        }
+
         var uploadedBefore = r.ReadString();
         UploadedBefore = string.IsNullOrEmpty(uploadedBefore) ? null : DateOnly.Parse(uploadedBefore);
         var uploadedAfter = r.ReadString();

--- a/Src/RandomizerTMF.Logic/Services/MapDownloader.cs
+++ b/Src/RandomizerTMF.Logic/Services/MapDownloader.cs
@@ -28,7 +28,7 @@ public class MapDownloader : IMapDownloader
     private readonly IGbxService gbxService;
     private readonly ILogger logger;
 
-    private readonly int requestMaxAttempts = 10;
+    private readonly int maxRequestMaxAttempts = 50;
     private int requestAttempt;
 
     public MapDownloader(IRandomizerEvents events,
@@ -158,7 +158,7 @@ public class MapDownloader : IMapDownloader
             TmxLink = tmxLink,
         });
 
-        discord.SessionMap(mapName, $"https://{requestUri.Host}/trackshow/{trackId}/image/1", map.Collection);
+        discord.SessionMap(mapName, $"https://{requestUri.Host}/trackshow/{trackId}/image/1", map.GetEnvironment());
 
         return true;
     }
@@ -279,6 +279,8 @@ public class MapDownloader : IMapDownloader
             logger.LogInformation("Map is invalid because {invalidBlock} is not valid for the {env} environment.", invalidBlock, map.Collection);
             await delayService.Delay(500, cancellationToken);
         }
+
+        var requestMaxAttempts = Math.Min(config.ValidationRetries, maxRequestMaxAttempts);
 
         Status($"Map is invalid (attempt {requestAttempt}/{requestMaxAttempts}).");
 

--- a/Src/RandomizerTMF.Logic/Services/RandomizerConfig.cs
+++ b/Src/RandomizerTMF.Logic/Services/RandomizerConfig.cs
@@ -18,6 +18,7 @@ public interface IRandomizerConfig
     bool DisableAutosaveDetailScan { get; set; }
     bool DisableAutoSkip { get; set; }
     AutoSkipMode AutoSkipMode { get; set; }
+    int ValidationRetries { get; set; }
     DiscordRichPresenceConfig DiscordRichPresence { get; set; }
     bool TopSessions { get; set; }
 
@@ -58,6 +59,9 @@ public class RandomizerConfig : IRandomizerConfig
 
     [YamlMember(Description = "When should automatic skip apply. Options are: AuthorMedal, GoldMedal, SilverMedal, BronzeMedal, Finished")]
     public AutoSkipMode AutoSkipMode { get; set; }
+
+    [YamlMember(Description = "How many attempts to try before terminating the session if randomly picked map fails validation. Hardcoded maximum is 50.")]
+    public int ValidationRetries { get; set; } = 10;
 
     [YamlMember(Description = "Discord Rich Presence configuration.")]
     public DiscordRichPresenceConfig DiscordRichPresence { get; set; } = new();

--- a/Src/RandomizerTMF.Logic/Services/RandomizerConfig.cs
+++ b/Src/RandomizerTMF.Logic/Services/RandomizerConfig.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Extensions.Logging;
+using RandomizerTMF.Logic.Exceptions;
 using System.IO.Abstractions;
 using System.Reflection;
 using YamlDotNet.Core;
@@ -101,12 +102,12 @@ public class RandomizerConfig : IRandomizerConfig
             catch (YamlException ex)
             {
                 logger.LogWarning(ex.InnerException, "Error while deserializing the config file ({configPath}; [{start}] - [{end}]).", Constants.ConfigYml, ex.Start, ex.End);
-                throw new Exception("Config file is corrupted or incorrectly formatted.");
+                throw new ConfigCorruptedException("Config file is corrupted or incorrectly formatted.", ex);
             }
             catch (Exception ex)
             {
                 logger.LogWarning(ex, "Error while deserializing the config file ({configPath}).", Constants.ConfigYml);
-                throw new Exception("Config file is corrupted or there's another problem.");
+                throw new ConfigCorruptedException("Config file is corrupted or there's another problem.", ex);
             }
         }
 

--- a/Src/RandomizerTMF.Logic/Services/RandomizerConfig.cs
+++ b/Src/RandomizerTMF.Logic/Services/RandomizerConfig.cs
@@ -97,16 +97,18 @@ public class RandomizerConfig : IRandomizerConfig
             catch (YamlException ex)
             {
                 logger.LogWarning(ex.InnerException, "Error while deserializing the config file ({configPath}; [{start}] - [{end}]).", Constants.ConfigYml, ex.Start, ex.End);
+                throw new Exception("Config file is corrupted or incorrectly formatted.");
             }
             catch (Exception ex)
             {
                 logger.LogWarning(ex, "Error while deserializing the config file ({configPath}).", Constants.ConfigYml);
+                throw new Exception("Config file is corrupted or there's another problem.");
             }
         }
 
         if (config is null)
         {
-            logger.LogInformation("Config file not found or is corrupted, creating a new one...");
+            logger.LogInformation("Config file not found, creating a new one...");
             config = new RandomizerConfig(logger, fileSystem);
         }
 

--- a/Src/RandomizerTMF.Logic/SessionData.cs
+++ b/Src/RandomizerTMF.Logic/SessionData.cs
@@ -233,7 +233,7 @@ public class SessionData
         }
 
         var version = reader.ReadByte();
-        if (version > 1)
+        if (version > 2)
         {
             throw new InvalidDataException("Invalid version.");
         }

--- a/Src/RandomizerTMF.Logic/SessionData.cs
+++ b/Src/RandomizerTMF.Logic/SessionData.cs
@@ -193,7 +193,7 @@ public class SessionData
 
     public void Serialize(BinaryWriter writer)
     {
-        const int version = 1;
+        const int version = 2;
 
         writer.Write("RandTMF");
         writer.Write((byte)version); // version

--- a/Src/RandomizerTMF/RandomizerTMF.csproj
+++ b/Src/RandomizerTMF/RandomizerTMF.csproj
@@ -5,7 +5,7 @@
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<Version>1.1.4</Version>
+		<Version>1.1.5</Version>
 		<PublishSingleFile>true</PublishSingleFile>
 		<EnableCompressionInSingleFile>true</EnableCompressionInSingleFile>
 	</PropertyGroup>

--- a/Src/RandomizerTMF/ViewModels/RequestRulesControlViewModel.cs
+++ b/Src/RandomizerTMF/ViewModels/RequestRulesControlViewModel.cs
@@ -934,6 +934,19 @@ internal class RequestRulesControlViewModel : WindowViewModelBase
         }
     }
 
+    public bool NoUnlimiter
+    {
+        get => config.Rules.NoUnlimiter;
+        set
+        {
+            config.Rules.NoUnlimiter = value;
+
+            this.RaisePropertyChanged(nameof(NoUnlimiter));
+
+            config.Save();
+        }
+    }
+
     public bool EqualEnvDistribution
     {
         get => config.Rules.RequestRules.EqualEnvironmentDistribution;

--- a/Src/RandomizerTMF/ViewModels/SessionDataViewModel.cs
+++ b/Src/RandomizerTMF/ViewModels/SessionDataViewModel.cs
@@ -161,7 +161,7 @@ internal class SessionDataViewModel : WindowWithTopBarViewModelBase
             }
             else
             {
-                val = null;
+                return;
             }
         }
 

--- a/Src/RandomizerTMF/Views/RequestRulesControl.axaml
+++ b/Src/RandomizerTMF/Views/RequestRulesControl.axaml
@@ -205,7 +205,7 @@
 				<CheckBox IsChecked="{Binding MaxATEnabled}" ToolTip.Tip="Enable/disable maximal author time filter."/>
 			</StackPanel>
 
-			<CheckBox Grid.Row="6" Grid.Column="2" IsChecked="True" Content="No Unlimiter maps" ToolTip.Tip="Avoid maps made in TMUnlimiter. There will be an option for Unlimiter only maps once TMX receives an Unlimiter map filter."/>
+			<CheckBox Grid.Row="6" Grid.Column="2" IsChecked="{Binding NoUnlimiter}" Content="No Unlimiter maps" ToolTip.Tip="Avoid maps made in TMUnlimiter. There will be an option for Unlimiter only maps once TMX receives an Unlimiter map filter."/>
 
 			<TextBlock Grid.Column="3" HorizontalAlignment="Right" VerticalAlignment="Center">Map name:</TextBlock>
 			<TextBox Grid.Column="5" Text="{Binding MapName}"/>

--- a/Tests/RandomizerTMF.Logic.Tests/RandomizerTMF.Logic.Tests.csproj
+++ b/Tests/RandomizerTMF.Logic.Tests/RandomizerTMF.Logic.Tests.csproj
@@ -13,7 +13,7 @@
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
 		<PackageReference Include="Moq" Version="4.20.70" />
 		<PackageReference Include="RichardSzalay.MockHttp" Version="7.0.0" />
-		<PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="21.0.22" />
+		<PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="21.0.29" />
 		<PackageReference Include="xunit" Version="2.9.0" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Tests/RandomizerTMF.Logic.Tests/Unit/Services/RandomizerConfigTests.cs
+++ b/Tests/RandomizerTMF.Logic.Tests/Unit/Services/RandomizerConfigTests.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.Logging;
 using Moq;
+using RandomizerTMF.Logic.Exceptions;
 using RandomizerTMF.Logic.Services;
 using System.IO.Abstractions.TestingHelpers;
 
@@ -48,7 +49,7 @@ public class RandomizerConfigTests
     [Theory]
     [InlineData(@"GameDirectory: [C:\GameDirectory")]
     [InlineData("ReplayParseFailRetries: number")]
-    public void GetOrCreate_CorruptedConfig_Overwrite(string configContent)
+    public void GetOrCreate_CorruptedConfig_Throws(string configContent)
     {
         // Arrange
         var mockLogger = new Mock<ILogger>();
@@ -59,16 +60,7 @@ public class RandomizerConfigTests
         var lastWriteTime = fileSystem.File.GetLastWriteTime("Config.yml");
         var defaultConfig = new RandomizerConfig();
 
-        // Act
-        var config = RandomizerConfig.GetOrCreate(mockLogger.Object, fileSystem);
-
-        // Assert
-        Assert.True(fileSystem.FileExists("Config.yml"));
-        Assert.NotEqual(expected: lastWriteTime, fileSystem.File.GetLastWriteTime("Config.yml"));
-        Assert.Equal(expected: defaultConfig.GameDirectory, actual: config.GameDirectory);
-        Assert.Equal(expected: defaultConfig.DownloadedMapsDirectory, actual: config.DownloadedMapsDirectory);
-        Assert.Equal(expected: defaultConfig.ReplayParseFailRetries, actual: config.ReplayParseFailRetries);
-        Assert.Equal(expected: defaultConfig.ReplayParseFailDelayMs, actual: config.ReplayParseFailDelayMs);
-        Assert.Equal(expected: defaultConfig.ReplayFileFormat, actual: config.ReplayFileFormat);
+        // Act & Assert
+        Assert.Throws<ConfigCorruptedException>(() => RandomizerConfig.GetOrCreate(mockLogger.Object, fileSystem));
     }
 }


### PR DESCRIPTION
- Added `InUnlimiter` to Config.yml in `RequestRules`
- Added `AvoidSkippedMaps` to Config.yml in `Rules` (default: `False`)
  - Skipped maps won't appear again in the session (only within that session though)
  - This will **not be valid for RMC** after discussion with original RMC devs (sessions driven with this option will be denied when submitting later)
- Added `ValidationRetries` to Config.yml (default: `10`)
- Fixed No Unlimiter checkbox not working
- Fixed banned maps being shown in the session rules window
- Config is no longer reset if it's corrupted
  - The program will not start instead (spawning messages boxes is hard here, always look into `RandomizerTMF.log` if something odd) 